### PR TITLE
feat: LuCI native UI, offload fixes, batch rDNS, per-device graph

### DIFF
--- a/.github/workflows/feature-build.yml
+++ b/.github/workflows/feature-build.yml
@@ -1,0 +1,86 @@
+name: Feature Build
+
+# Builds an IPK from any feature/* branch and publishes it as a
+# floating pre-release so the download URL stays stable across pushes.
+#
+# Release tag:  build-feature-<branch-slug>
+# Download URL: …/releases/download/build-feature-<slug>/luci-app-trafficctl.ipk
+
+on:
+  push:
+    branches:
+      - 'feature/**'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build IPK — ${{ github.ref_name }}
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Derive metadata
+        id: meta
+        run: |
+          SAFE=$(echo "${GITHUB_REF_NAME}" | tr '/' '-' | tr '_' '-' | sed 's/[^a-zA-Z0-9-]//g')
+          SHA="${GITHUB_SHA:0:7}"
+          DATE=$(date -u +"%Y-%m-%d %H:%M UTC")
+          echo "safe=$SAFE"         >> "$GITHUB_OUTPUT"
+          echo "sha=$SHA"           >> "$GITHUB_OUTPUT"
+          echo "tag=build-${SAFE}"  >> "$GITHUB_OUTPUT"
+          echo "date=$DATE"         >> "$GITHUB_OUTPUT"
+
+      - name: Build .ipk
+        run: |
+          ./build-ipk.sh "0.0.0-${{ steps.meta.outputs.sha }}" 0
+          ln -f dist/luci-app-trafficctl_*_all.ipk dist/luci-app-trafficctl.ipk
+          ls -la dist/luci-app-trafficctl.ipk
+
+      - name: Smoke-test the IPK
+        run: sh tests/test_build_ipk.sh
+
+      - name: Delete previous floating release (if any)
+        run: |
+          TAG="${{ steps.meta.outputs.tag }}"
+          gh release delete "$TAG" --yes 2>/dev/null || true
+          git push origin ":refs/tags/$TAG"  2>/dev/null || true
+
+      - name: Publish pre-release
+        run: |
+          TAG="${{ steps.meta.outputs.tag }}"
+          SHA="${{ steps.meta.outputs.sha }}"
+          DATE="${{ steps.meta.outputs.date }}"
+          BRANCH="${GITHUB_REF_NAME}"
+          REPO="${GITHUB_REPOSITORY}"
+
+          gh release create "$TAG" dist/luci-app-trafficctl.ipk \
+            --prerelease \
+            --title "Dev: ${BRANCH} @ ${SHA}" \
+            --notes "$(cat <<NOTES
+## Dev build — \`${BRANCH}\`
+
+Built from [\`${SHA}\`](https://github.com/${REPO}/commit/${GITHUB_SHA}) · ${DATE}
+
+> ⚠️ Pre-release for testing only — not for production.
+
+### Install (OpenWrt 21.02 – 24.10)
+
+\`\`\`sh
+opkg install https://github.com/${REPO}/releases/download/${TAG}/luci-app-trafficctl.ipk
+\`\`\`
+
+Or via LuCI → **System → Software → Upload Package**.
+
+### Update
+
+Re-run the same command — opkg will reinstall over the existing version.
+NOTES
+)"

--- a/.github/workflows/feature-build.yml
+++ b/.github/workflows/feature-build.yml
@@ -1,10 +1,12 @@
 name: Feature Build
 
-# Builds an IPK from any feature/* branch and publishes it as a
-# floating pre-release so the download URL stays stable across pushes.
+# Builds IPK + APK from any feature/* branch and publishes them as a
+# floating pre-release so the download URLs stay stable across pushes.
 #
 # Release tag:  build-feature-<branch-slug>
-# Download URL: …/releases/download/build-feature-<slug>/luci-app-trafficctl.ipk
+# Download URLs:
+#   …/releases/download/build-feature-<slug>/luci-app-trafficctl.ipk
+#   …/releases/download/build-feature-<slug>/luci-app-trafficctl.apk
 
 on:
   push:
@@ -16,12 +18,13 @@ permissions:
   contents: write
 
 jobs:
-  build:
-    name: Build IPK — ${{ github.ref_name }}
+  build-ipk:
+    name: Build IPK
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ github.token }}
-
+    outputs:
+      tag:  ${{ steps.meta.outputs.tag }}
+      sha:  ${{ steps.meta.outputs.sha }}
+      date: ${{ steps.meta.outputs.date }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -42,26 +45,84 @@ jobs:
         run: |
           ./build-ipk.sh "0.0.0-${{ steps.meta.outputs.sha }}" 0
           ln -f dist/luci-app-trafficctl_*_all.ipk dist/luci-app-trafficctl.ipk
-          ls -la dist/luci-app-trafficctl.ipk
 
       - name: Smoke-test the IPK
         run: sh tests/test_build_ipk.sh
 
+      - name: Upload IPK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ipk
+          path: dist/luci-app-trafficctl.ipk
+
+  build-apk:
+    name: Build APK
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Patch Makefile version
+        run: |
+          SHA="${GITHUB_SHA:0:7}"
+          sed -i "s/^PKG_VERSION:=.*/PKG_VERSION:=0.0.0-${SHA}/" luci-app-trafficctl/Makefile
+          sed -i "s/^PKG_RELEASE:=.*/PKG_RELEASE:=0/"            luci-app-trafficctl/Makefile
+
+      - name: Build .apk via OpenWrt SDK
+        uses: openwrt/gh-action-sdk@main
+        env:
+          ARCH: x86_64-25.12.4
+          FEEDNAME: trafficctl
+          PACKAGES: luci-app-trafficctl
+          V: sc
+
+      - name: Collect APK
+        run: |
+          APK=$(find bin/ -name "luci-app-trafficctl*.apk" 2>/dev/null | head -1)
+          if [ -z "$APK" ]; then
+            echo "::error::APK not found in SDK output"
+            find bin/ -type f -name "*.apk" || true
+            exit 1
+          fi
+          cp "$APK" luci-app-trafficctl.apk
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: apk
+          path: luci-app-trafficctl.apk
+
+  publish:
+    name: Publish pre-release
+    runs-on: ubuntu-latest
+    needs: [build-ipk, build-apk]
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: dist/
+
       - name: Delete previous floating release (if any)
         run: |
-          TAG="${{ steps.meta.outputs.tag }}"
+          TAG="${{ needs.build-ipk.outputs.tag }}"
           gh release delete "$TAG" --yes 2>/dev/null || true
-          git push origin ":refs/tags/$TAG"  2>/dev/null || true
+          git push origin ":refs/tags/$TAG" 2>/dev/null || true
 
-      - name: Publish pre-release
+      - name: Create pre-release
         run: |
-          TAG="${{ steps.meta.outputs.tag }}"
-          SHA="${{ steps.meta.outputs.sha }}"
-          DATE="${{ steps.meta.outputs.date }}"
+          TAG="${{ needs.build-ipk.outputs.tag }}"
+          SHA="${{ needs.build-ipk.outputs.sha }}"
+          DATE="${{ needs.build-ipk.outputs.date }}"
           BRANCH="${GITHUB_REF_NAME}"
           REPO="${GITHUB_REPOSITORY}"
 
-          gh release create "$TAG" dist/luci-app-trafficctl.ipk \
+          gh release create "$TAG" dist/luci-app-trafficctl.ipk dist/luci-app-trafficctl.apk \
             --prerelease \
             --title "Dev: ${BRANCH} @ ${SHA}" \
             --notes "$(cat <<NOTES
@@ -71,16 +132,19 @@ Built from [\`${SHA}\`](https://github.com/${REPO}/commit/${GITHUB_SHA}) · ${DA
 
 > ⚠️ Pre-release for testing only — not for production.
 
-### Install (OpenWrt 21.02 – 24.10)
+| File | OpenWrt version | Command |
+|------|----------------|---------|
+| \`luci-app-trafficctl.ipk\` | 21.02 – 24.10 | \`opkg install <url>\` |
+| \`luci-app-trafficctl.apk\` | 25.12+ | \`apk add --allow-untrusted <url>\` |
+
+### Install
 
 \`\`\`sh
+# OpenWrt 21.02 – 24.10
 opkg install https://github.com/${REPO}/releases/download/${TAG}/luci-app-trafficctl.ipk
+
+# OpenWrt 25.12+
+apk add --allow-untrusted https://github.com/${REPO}/releases/download/${TAG}/luci-app-trafficctl.apk
 \`\`\`
-
-Or via LuCI → **System → Software → Upload Package**.
-
-### Update
-
-Re-run the same command — opkg will reinstall over the existing version.
 NOTES
 )"

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ I hope it turns out as useful for you as it has been for me.
 | `iw-full` | Interface detection | WiFi band identification |
 | `bridge-utils` | Interface detection | LAN port identification (brctl) |
 | `curl` + `jsonfilter` | Telegram bot | jsonfilter is part of base OpenWrt |
-| `bind-dig` | Reverse DNS | Optional, for hostname resolution |
+| `rpcd-mod-rrdns` | Reverse DNS | Included with `rpcd`; enables rDNS in LuCI, Telegram, and CLI |
 
 ## Compatibility
 
@@ -209,16 +209,16 @@ Runs on all architectures (no compiled code, pure shell + LuCI JavaScript).
 
 **CI-tested on 52 combinations** — every push is verified against real OpenWrt rootfs containers:
 
-| | x86‑64 | x86‑generic | mips\_24kc | aarch64 | arm\_a9 | arm\_a15 | armsr | i386 |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
-| **21.02.6** | ✓ | | | ✓ | | ✓ | | |
-| **22.03.7** | ✓ | | | ✓ | | ✓ | | |
-| **23.05.6** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| **24.10.1** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| **24.10.6** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| **25.12.0** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| **25.12.4** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| **snapshot** | ✓ | | ✓ | ✓ | | | ✓ | |
+| | x86‑64 | x86‑generic | mips\_24kc | aarch64 | arm\_a9 | arm\_a15 | armsr | armvirt32 | i386 |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| **21.02.6** | ✓ | | | ✓ | | ✓ | | ✓ | |
+| **22.03.7** | ✓ | | | ✓ | | ✓ | | ✓ | |
+| **23.05.6** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | | ✓ |
+| **24.10.1** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | | ✓ |
+| **24.10.6** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | | ✓ |
+| **25.12.0** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | | ✓ |
+| **25.12.4** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | | ✓ |
+| **snapshot** | ✓ | | ✓ | ✓ | | | ✓ | | |
 
 Each test builds the `.ipk`, runs `opkg install --force-depends` inside the real OpenWrt rootfs container for that version/arch, then verifies all files are present and all scripts pass `ash -n` syntax check.
 
@@ -328,8 +328,7 @@ apk add tc-full kmod-sched-core kmod-sched-htb
 # For interface detection (WiFi band + LAN port)
 apk add iw-full bridge-utils
 
-# For reverse DNS (optional)
-apk add bind-dig
+# rpcd-mod-rrdns is included with rpcd (no extra install needed)
 
 # For Telegram bot (optional)
 apk add curl
@@ -350,8 +349,7 @@ opkg install tc-full kmod-sched-core kmod-sched-htb
 # For interface detection (WiFi band + LAN port)
 opkg install iw-full bridge-utils
 
-# For reverse DNS (optional)
-opkg install bind-dig
+# rpcd-mod-rrdns is included with rpcd (no extra install needed)
 
 # For Telegram bot (optional)
 opkg install curl
@@ -455,6 +453,7 @@ The frontend talks to a thin rpcd dispatcher over ubus. The Telegram bot provide
 | Path | Role |
 |------|------|
 | `luci-app-trafficctl/htdocs/.../view/trafficctl/status.js` | Frontend — single ES5 file, no deps |
+| `luci-app-trafficctl/htdocs/.../view/trafficctl/status.css` | Frontend styles |
 | `luci-app-trafficctl/root/usr/libexec/rpcd/luci.trafficctl` | rpcd backend — JSON-RPC dispatch |
 | `luci-app-trafficctl/root/usr/local/bin/trafficctl-*.sh` | Backend scripts (monitoring + control) |
 | `luci-app-trafficctl/root/usr/local/bin/trafficctl-fw.sh` | Firewall abstraction layer (sourced) |

--- a/build-ipk.sh
+++ b/build-ipk.sh
@@ -28,7 +28,7 @@ chmod +x "$DATA/usr/local/bin/trafficctl-"*.sh
 chmod +x "$DATA/usr/libexec/rpcd/luci.trafficctl"
 [ -d "$DATA/etc/init.d" ] && chmod +x "$DATA/etc/init.d/"*
 
-(cd "$DATA" && tar czf "$WORKDIR/data.tar.gz" .)
+(cd "$DATA" && COPYFILE_DISABLE=1 tar --exclude='._*' -cf - . | gzip -9 > "$WORKDIR/data.tar.gz")
 
 # Build control.tar.gz — package metadata
 CTRL="$WORKDIR/control"
@@ -87,7 +87,7 @@ exit 0
 EOF
 chmod +x "$CTRL/prerm"
 
-(cd "$CTRL" && tar czf "$WORKDIR/control.tar.gz" .)
+(cd "$CTRL" && COPYFILE_DISABLE=1 tar --exclude='._*' -cf - . | gzip -9 > "$WORKDIR/control.tar.gz")
 
 # Assemble ipk: gzip-compressed tar archive (OpenWrt opkg format, NOT Debian ar)
 echo "2.0" > "$WORKDIR/debian-binary"
@@ -95,6 +95,6 @@ echo "2.0" > "$WORKDIR/debian-binary"
 mkdir -p "$OUTDIR"
 IPK_FILE="$OUTDIR/${PKG_NAME}_${PKG_VERSION}-${PKG_RELEASE}_${PKG_ARCH}.ipk"
 
-(cd "$WORKDIR" && tar --numeric-owner --owner=0 --group=0 -czf "$OLDPWD/$IPK_FILE" ./debian-binary ./control.tar.gz ./data.tar.gz)
+(cd "$WORKDIR" && COPYFILE_DISABLE=1 tar --exclude='._*' -cf - ./debian-binary ./control.tar.gz ./data.tar.gz | gzip -9 > "$OLDPWD/$IPK_FILE")
 
 echo "$IPK_FILE"

--- a/build-ipk.sh
+++ b/build-ipk.sh
@@ -28,7 +28,7 @@ chmod +x "$DATA/usr/local/bin/trafficctl-"*.sh
 chmod +x "$DATA/usr/libexec/rpcd/luci.trafficctl"
 [ -d "$DATA/etc/init.d" ] && chmod +x "$DATA/etc/init.d/"*
 
-(cd "$DATA" && COPYFILE_DISABLE=1 tar --exclude='._*' -cf - . | gzip -9 > "$WORKDIR/data.tar.gz")
+(cd "$DATA" && COPYFILE_DISABLE=1 tar --format ustar --exclude='._*' -cf - . | gzip -9 > "$WORKDIR/data.tar.gz")
 
 # Build control.tar.gz — package metadata
 CTRL="$WORKDIR/control"
@@ -87,7 +87,7 @@ exit 0
 EOF
 chmod +x "$CTRL/prerm"
 
-(cd "$CTRL" && COPYFILE_DISABLE=1 tar --exclude='._*' -cf - . | gzip -9 > "$WORKDIR/control.tar.gz")
+(cd "$CTRL" && COPYFILE_DISABLE=1 tar --format ustar --exclude='._*' -cf - . | gzip -9 > "$WORKDIR/control.tar.gz")
 
 # Assemble ipk: gzip-compressed tar archive (OpenWrt opkg format, NOT Debian ar)
 echo "2.0" > "$WORKDIR/debian-binary"
@@ -95,6 +95,6 @@ echo "2.0" > "$WORKDIR/debian-binary"
 mkdir -p "$OUTDIR"
 IPK_FILE="$OUTDIR/${PKG_NAME}_${PKG_VERSION}-${PKG_RELEASE}_${PKG_ARCH}.ipk"
 
-(cd "$WORKDIR" && COPYFILE_DISABLE=1 tar --exclude='._*' -cf - ./debian-binary ./control.tar.gz ./data.tar.gz | gzip -9 > "$OLDPWD/$IPK_FILE")
+(cd "$WORKDIR" && COPYFILE_DISABLE=1 tar --format ustar --exclude='._*' -cf - ./debian-binary ./control.tar.gz ./data.tar.gz | gzip -9 > "$OLDPWD/$IPK_FILE")
 
 echo "$IPK_FILE"

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,6 +1,6 @@
 # API Reference
 
-All backend functionality is exposed through shell scripts in `/usr/local/bin/trafficctl-*.sh`. The LuCI frontend calls them via JSON-RPC through the rpcd backend at `/usr/libexec/rpcd/trafficctl`.
+All backend functionality is exposed through shell scripts in `/usr/local/bin/trafficctl-*.sh`. The LuCI frontend calls them via JSON-RPC through the rpcd backend at `/usr/libexec/rpcd/luci.trafficctl`.
 
 ---
 
@@ -34,8 +34,8 @@ The frontend calls these via `rpc.declare()`:
 | `macfilter_add` | `trafficctl-macfilter-add.sh` | `ip` |
 | `macfilter_remove` | `trafficctl-macfilter-remove.sh` | `ip` |
 | `rdns` | `trafficctl-rdns.sh` | `ip` |
-| `config_get` | (inline) | (none) |
-| `config_set` | (inline) | `enabled`, `default_mode` |
+| `config_get` | (inline) | (none) — returns `enabled`, `default_mode`, `offload_mode`, `sw`, `hw` |
+| `config_set` | (inline) | `enabled`, `default_mode`, `sw`, `hw` (all optional) |
 | `telegram_config_get` | (inline) | (none) |
 | `telegram_config_set` | (inline) | `enabled`, `bot_token`, `chat_id`, `poll_interval`, `notify_new_device`, `notify_known_device`, `btn_block_inet`, `btn_block_wifi`, `btn_limiter`, `btn_shaper` |
 | `telegram_test` | `trafficctl-telegram-test.sh` | `bot_token`, `chat_id` |
@@ -197,7 +197,8 @@ Returns `[]` if tc is not installed or no HTB qdisc exists.
 
 ### trafficctl-rdns.sh
 
-Reverse DNS lookup for a single IP.
+Reverse DNS lookup for a single IP. Used by the Telegram bot and the rpcd `rdns` ubus
+method. The LuCI frontend uses `network.rrdns.lookup` directly for batch resolution.
 
 **Arguments:** `<ip>`
 
@@ -207,7 +208,8 @@ Reverse DNS lookup for a single IP.
 {"ip": "140.82.121.3", "host": "lb-140-82-121-3-iad.github.com"}
 ```
 
-Uses `dig -x` with `+time=1 +tries=1`. Requires `bind-dig`.
+Uses `ubus call network.rrdns lookup` (rpcd-mod-rrdns, ships with rpcd) with BusyBox
+`nslookup` as a fallback. No `bind-dig` required.
 
 ---
 
@@ -261,7 +263,7 @@ Manage tc/HTB traffic shaping.
 {"ok": true, "ip": "192.168.0.111", "classid": "1:6f", "info": "rate 10000Kbit"}
 ```
 
-**Persistence:** Writes to `/etc/trafficmon/shapes.json` on every add/remove.
+**Persistence:** Writes to `/etc/trafficctl/shapes.json` on every add/remove.
 
 ---
 
@@ -309,7 +311,7 @@ Bot daemon using Telegram long polling. Runs under procd.
 | `act:unshape:<ip>` | Remove shaper |
 | `act:back` | Return to device list |
 
-**Known devices file:** `/etc/trafficmon/telegram_known.json` -- tracks MACs for new device notifications.
+**Known devices file:** `/etc/trafficctl/telegram_known.json` -- tracks MACs for new device notifications.
 
 ### trafficctl-telegram-test.sh
 
@@ -323,4 +325,4 @@ Validates token format and chat_id, sends a test message. Returns `{"ok":true,"m
 
 ## rpcd ACL
 
-The ACL file at `/usr/share/rpcd/acl.d/luci-app-trafficctl.json` grants execution permissions. The rpcd backend at `/usr/libexec/rpcd/trafficctl` handles method dispatch and parameter validation.
+The ACL file at `/usr/share/rpcd/acl.d/luci-app-trafficctl.json` grants execution permissions. The rpcd backend at `/usr/libexec/rpcd/luci.trafficctl` handles method dispatch and parameter validation.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -26,16 +26,17 @@ graph TD
     subgraph "Router (Server)"
         subgraph "rpcd + uhttpd"
             ACL["luci-app-trafficctl.json<br/>(ACL definitions)"]
-            RPC["/usr/libexec/rpcd/trafficctl<br/>(JSON-RPC dispatch)"]
+            RPC["/usr/libexec/rpcd/luci.trafficctl<br/>(JSON-RPC dispatch)"]
         end
 
         subgraph "Query Scripts — /usr/local/bin/"
             SUM["trafficctl-summary.sh<br/>(all active devices)"]
             DEV["trafficctl-device.sh<br/>(per-device connections)"]
             BYT["trafficctl-bytes.sh<br/>(conntrack byte counters)"]
+            BYTNFT["trafficctl-bytes-nft.sh<br/>(nft counter init helper)"]
             RLS["trafficctl-ratelimit-stats.sh<br/>(nft drop counters)"]
             SHS["trafficctl-shape-stats.sh<br/>(tc class stats)"]
-            RDNS["trafficctl-rdns.sh<br/>(reverse DNS lookup)"]
+            RDNS["trafficctl-rdns.sh<br/>(reverse DNS — Telegram/CLI)"]
         end
 
         subgraph "Action Scripts — /usr/local/bin/"
@@ -61,7 +62,7 @@ graph TD
         end
 
         subgraph "Persistence"
-            SHAPES["/etc/trafficmon/shapes.json"]
+            SHAPES["/etc/trafficctl/shapes.json"]
             HOTPLUG["/etc/hotplug.d/iface/<br/>99-trafficctl-shapes"]
         end
     end
@@ -140,14 +141,10 @@ sequenceDiagram
     D->>D: tc class check (shape status)
     D-->>B: {ip, name, mac, conn_type, connections[], ...}
 
-    par rDNS resolution (if enabled)
-        B->>R: rdns(dst_ip_1)
-        R->>DNS: dig -x dst_ip_1
-        DNS-->>B: {ip, host}
-    and
-        B->>R: rdns(dst_ip_2)
-        R->>DNS: dig -x dst_ip_2
-        DNS-->>B: {ip, host}
+    opt rDNS resolution (if enabled)
+        B->>R: network.rrdns.lookup(addrs[], timeout, limit)
+        Note over R: rpcd-mod-rrdns resolves all IPs in one batch
+        R-->>B: {ip1: "host1", ip2: "host2", ...}
     end
 ```
 
@@ -326,15 +323,22 @@ Speed is calculated as `(bytes_now - bytes_prev) / dt` for both download and upl
 - `_speedHistory` -- sliding window (trimmed to avgWindow/pollInterval samples) for sparkline and averaging.
 - `_fullHistory` -- never trimmed, used by the popup graph to show the entire session.
 
-### Popup Graph Features
+### Graph Features
 
+Two rendering contexts use the same `renderFullGraph()` function:
+
+**Hover popup** (any sparkline): interactive SVG overlay.
+**Inline device graph** (device detail view): static SVG rendered below the action buttons when a specific device is selected. Updates on every bytes poll.
+
+Both share:
 - Dual lines: download (solid blue) + upload (dashed green)
 - Gradient area fill with linear gradient
 - Min/max band (rolling window ±5 points)
-- Interactive crosshair with precise DL/UL values
 - Rate limit line (from shapeMap or summary data)
 - Nice Y-axis ticks (multiples of 100/500 Kbit/s, min 5 grid lines)
 - 98th percentile scaling (outliers don't crush the graph)
+
+The popup additionally has an interactive crosshair with precise DL/UL values.
 
 Polling stops when:
 - The browser tab is hidden (`document.hidden === true`).
@@ -368,12 +372,12 @@ This approach disconnects only the target client. All other WiFi clients remain 
 
 | Feature | Persisted | Storage | Rationale |
 |---------|-----------|---------|-----------|
-| Shaping (tc/HTB) | Always | `shapes.json` | Long-term bandwidth allocation |
-| Rate limiting (nft policer) | Optional (`persist_rules`) | `rules.json` | Configurable -- may be temporary or permanent |
-| Internet blocking | Optional (`persist_rules`) | `rules.json` | Configurable -- may be temporary or permanent |
+| Shaping (tc/HTB) | Always | `/etc/trafficctl/shapes.json` | Long-term bandwidth allocation |
+| Rate limiting (nft policer) | Optional (`persist_rules`) | `/etc/trafficctl/rules.json` | Configurable -- may be temporary or permanent |
+| Internet blocking | Optional (`persist_rules`) | `/etc/trafficctl/rules.json` | Configurable -- may be temporary or permanent |
 | WiFi MAC filtering | Always | `uci commit wireless` | Committed to `/etc/config/wireless` |
 
-The hotplug script triggers on `ACTION=ifup` and `INTERFACE=lan`, with a readiness loop (waits up to 10s for tc to be available on the bridge device). When `persist_rules` is enabled, blocks and ratelimits are saved/removed from `/etc/trafficmon/rules.json` alongside shape operations.
+The hotplug script triggers on `ACTION=ifup` and `INTERFACE=lan`, with a readiness loop (waits up to 10s for tc to be available on the bridge device). When `persist_rules` is enabled, blocks and ratelimits are saved/removed from `/etc/trafficctl/rules.json` alongside shape operations.
 
 ---
 
@@ -394,7 +398,7 @@ Telegram API  ←──curl long poll──  trafficctl-telegram.sh (procd)
 - **Polling:** `getUpdates?timeout=N` acts as both fetch and sleep — no separate timer needed.
 - **Security:** Only responds to messages from the configured `chat_id`. Unauthorized messages are silently dropped.
 - **Device cache:** Summary output is cached for 5 seconds in `/tmp/trafficctl_tg_devices.json`.
-- **Known devices:** `/etc/trafficmon/telegram_known.json` tracks MACs for new device notifications.
+- **Known devices:** `/etc/trafficctl/telegram_known.json` tracks MACs for new device notifications.
 - **Configuration:** UCI section `trafficctl.telegram` with token, chat_id, notification and button toggles. Token is masked (never returned to the frontend).
 - **Init:** procd `respawn 3600 5 5` + `service_triggers` for auto-reload on UCI commit.
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -62,13 +62,13 @@ The package contains no compiled code (all shell scripts and JavaScript), so it 
 
 If `tc` is not installed, the shaping feature gracefully degrades: the UI still works but shaper actions return an error message explaining what to install.
 
-### For Reverse DNS (optional)
+### For Reverse DNS
 
-| Package | Purpose | Size |
-|---------|---------|------|
-| `bind-dig` | DNS reverse lookup tool | ~200 KB |
+Reverse DNS uses `ubus call network.rrdns lookup` — the same built-in rpcd module that
+the LuCI connections page uses. It is provided by `rpcd-mod-rrdns`, which ships with
+`rpcd` on all modern OpenWrt builds and requires no separate install.
 
-Without `bind-dig`, reverse DNS lookups silently return empty hostnames.
+BusyBox `nslookup` (always available) is used as a fallback if rpcd-mod-rrdns is absent.
 
 ### For Interface Detection (optional)
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -21,11 +21,12 @@ scp luci-app-trafficctl/root/usr/local/bin/trafficctl-*.sh root@192.168.0.1:/usr
 ssh root@192.168.0.1 'chmod +x /usr/local/bin/trafficctl-*.sh'
 
 # Deploy rpcd backend
-scp luci-app-trafficctl/root/usr/libexec/rpcd/trafficctl root@192.168.0.1:/usr/libexec/rpcd/
-ssh root@192.168.0.1 'chmod +x /usr/libexec/rpcd/trafficctl && /etc/init.d/rpcd restart'
+scp luci-app-trafficctl/root/usr/libexec/rpcd/luci.trafficctl root@192.168.0.1:/usr/libexec/rpcd/
+ssh root@192.168.0.1 'chmod +x /usr/libexec/rpcd/luci.trafficctl && /etc/init.d/rpcd restart'
 
 # Deploy frontend
 scp luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.js \
+    luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.css \
     root@192.168.0.1:/www/luci-static/resources/view/trafficctl/
 ```
 
@@ -74,7 +75,8 @@ make package/luci-app-trafficctl/compile V=s
 ```
 luci-app-trafficctl/
 ├── luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/
-│   └── status.js                        # Frontend (single ES5 file, ~1800 lines)
+│   ├── status.js                        # Frontend (single ES5 file, ~3100 lines)
+│   └── status.css                       # Frontend styles (~610 lines)
 ├── luci-app-trafficctl/root/
 │   ├── etc/
 │   │   ├── config/trafficctl            # UCI config placeholder
@@ -82,12 +84,13 @@ luci-app-trafficctl/
 │   │       └── 99-trafficctl-shapes     # Restore tc rules on boot
 │   ├── usr/
 │   │   ├── libexec/rpcd/
-│   │   │   └── trafficctl              # rpcd backend (JSON-RPC dispatch)
+│   │   │   └── luci.trafficctl         # rpcd backend (JSON-RPC dispatch)
 │   │   ├── local/bin/
 │   │   │   ├── trafficctl-fw.sh        # Firewall abstraction (sourced)
 │   │   │   ├── trafficctl-summary.sh   # All-device summary
 │   │   │   ├── trafficctl-device.sh    # Per-device detail
-│   │   │   ├── trafficctl-bytes.sh     # Byte counters for speed
+│   │   │   ├── trafficctl-bytes.sh     # Byte counters for speed (conntrack)
+│   │   │   ├── trafficctl-bytes-nft.sh # nft counter init helper
 │   │   │   ├── trafficctl-block.sh     # Internet block
 │   │   │   ├── trafficctl-unblock.sh   # Internet unblock
 │   │   │   ├── trafficctl-shape.sh     # tc/HTB shaping
@@ -96,7 +99,7 @@ luci-app-trafficctl/
 │   │   │   ├── trafficctl-ratelimit-stats.sh
 │   │   │   ├── trafficctl-macfilter-add.sh
 │   │   │   ├── trafficctl-macfilter-remove.sh
-│   │   │   └── trafficctl-rdns.sh      # Reverse DNS
+│   │   │   └── trafficctl-rdns.sh      # Reverse DNS (Telegram/CLI)
 │   │   └── share/
 │   │       ├── luci/menu.d/
 │   │       │   └── luci-app-trafficctl.json
@@ -234,18 +237,18 @@ GitHub Actions (`.github/workflows/`) runs on every push and PR:
 
 **"Permission denied" from LuCI:**
 - Check ACL file exists at `/usr/share/rpcd/acl.d/luci-app-trafficctl.json`
-- Ensure rpcd backend is executable: `chmod +x /usr/libexec/rpcd/trafficctl`
+- Ensure rpcd backend is executable: `chmod +x /usr/libexec/rpcd/luci.trafficctl`
 - Restart rpcd: `/etc/init.d/rpcd restart`
 
 **Script works via SSH but not from LuCI:**
-- rpcd backend needs `list` and method handlers. Check `/usr/libexec/rpcd/trafficctl`.
+- rpcd backend needs `list` and method handlers. Check `/usr/libexec/rpcd/luci.trafficctl`.
 
 **tc commands fail:**
 - Verify `tc-full` (not minimal `tc`): `opkg install tc-full kmod-sched-htb`
 - Check kernel module: `lsmod | grep sch_htb`
 
 **Shaping not restored after reboot:**
-- Check `/etc/trafficmon/shapes.json` exists with valid JSON
+- Check `/etc/trafficctl/shapes.json` exists with valid JSON
 - Test hotplug manually: `ACTION=ifup INTERFACE=lan sh /etc/hotplug.d/iface/99-trafficctl-shapes`
 
 **Debug logging:**

--- a/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.css
+++ b/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.css
@@ -384,6 +384,22 @@
 }
 
 /* ── Extended stats panel ────────────────────────────────────────── */
+.tc-offload-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 6px;
+}
+.tc-offload-row--hw {
+    margin-top: 10px;
+}
+.tc-offload-desc {
+    font-size: 11px;
+    color: var(--tc-muted);
+    margin: 2px 0 0 32px;
+    line-height: 1.5;
+}
+
 .tc-device-graph {
     margin: 8px 0;
     border: 1px solid var(--tc-border);

--- a/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.css
+++ b/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.css
@@ -1,255 +1,205 @@
-/* trafficctl status view — consolidated styles */
+/* trafficctl status view — native LuCI UI variant */
+
+/* ── Semantic colour bridge (LuCI-native → tc-* aliases) ───────────── */
+:root {
+    --tc-speed:   var(--primary-color-high,   #3182ce);
+    --tc-ok:      var(--success-color-high,   #276749);
+    --tc-warn:    var(--warn-color-high,      #c05621);
+    --tc-err:     var(--error-color-high,     #c53030);
+    --tc-muted:   var(--text-color-medium,    #718096);
+    --tc-faint:   var(--text-color-low,       #a0aec0);
+    --tc-border:  var(--border-color-medium,  #e2e8f0);
+    --tc-bg:      var(--background-color-high,#ffffff);
+    --tc-bg-alt:  var(--background-color-low, #f7fafc);
+    --tc-hover:   var(--background-color-low, #ebf8ff);
+}
+
+/* Bootstrap explicit dark mode */
+:root[data-darkmode="true"], html[data-darkmode="true"] {
+    --tc-speed:   #63b3ed;
+    --tc-ok:      #68d391;
+    --tc-warn:    #f6ad55;
+    --tc-err:     #fc8181;
+    --tc-muted:   #a0aec0;
+    --tc-faint:   #718096;
+    --tc-border:  #3a3a3a;
+    --tc-bg:      #1e1e1e;
+    --tc-bg-alt:  #262626;
+    --tc-hover:   #2d3748;
+}
+
+/* OS dark preference (Argon auto mode, other themes) */
+@media (prefers-color-scheme: dark) {
+    :root:not([data-darkmode="false"]) {
+        --tc-speed:   #63b3ed;
+        --tc-ok:      #68d391;
+        --tc-warn:    #f6ad55;
+        --tc-err:     #fc8181;
+        --tc-muted:   #a0aec0;
+        --tc-faint:   #718096;
+        --tc-border:  #3a3a3a;
+        --tc-bg:      #1e1e1e;
+        --tc-bg-alt:  #262626;
+        --tc-hover:   #2d3748;
+    }
+}
 
 /* ── Utility ─────────────────────────────────────────────────────── */
-.tm-hidden { display: none !important; }
+.tc-hidden { display: none !important; }
+
+/* ── Colour utilities ────────────────────────────────────────────── */
+.tc-c-speed  { color: var(--tc-speed); }
+.tc-c-ok     { color: var(--tc-ok); }
+.tc-c-warn   { color: var(--tc-warn); }
+.tc-c-err    { color: var(--tc-err); }
+.tc-c-muted  { color: var(--tc-muted); }
+.tc-c-faint  { color: var(--tc-faint); }
+.tc-fw-bold  { font-weight: 600; }
+.tc-mono     { font-family: monospace; }
+.tc-right    { text-align: right; }
+.tc-center   { text-align: center; }
+.tc-sm       { font-size: 11px; }
+
+/* ── Table extras ────────────────────────────────────────────────── */
+/* Base styles come from LuCI's .table .tr .th .td cascade */
+.table.tc-table .th { cursor: pointer; user-select: none; white-space: nowrap; font-size: 12px; }
+.table.tc-table .th:hover { opacity: 0.75; }
+.table.tc-table .td { font-size: 12px; vertical-align: middle; }
+.table.tc-table .tr:not(.cbi-section-table-titles):hover .td {
+    background: var(--tc-hover);
+    cursor: pointer;
+}
+
+/* ── Speed indicator in table ────────────────────────────────────── */
+.tc-speed-active { color: var(--tc-speed); font-weight: 600; }
+.tc-speed-idle   { color: var(--tc-faint); }
+
+/* ── Inline badge (block/limit/shape status in cell) ─────────────── */
+.tc-badge {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 3px;
+    font-size: 11px;
+    font-weight: 600;
+    white-space: nowrap;
+}
+.tc-badge--blocked { color: var(--tc-err); }
+.tc-badge--limited { color: var(--tc-warn); }
+.tc-badge--shaped  { color: var(--tc-speed); }
+.tc-badge--wifi    { color: var(--tc-ok); }
+.tc-badge--drop    { color: var(--tc-err); }
 
 /* ── Offload banner ───────────────────────────────────────────────── */
-.tm-offload-banner {
+.tc-offload-banner {
     padding: 10px 14px;
     margin-bottom: 8px;
     border-radius: 6px;
     font-size: 13px;
     line-height: 1.5;
 }
-
-.tm-offload-banner__row {
+.tc-offload-banner__row {
     display: flex;
     justify-content: space-between;
     align-items: flex-start;
 }
-
-.tm-offload-banner__icon {
+.tc-offload-banner__icon {
     font-size: 15px;
     margin-right: 8px;
 }
-
-.tm-offload-banner__body {
-    flex: 1;
-}
-
-.tm-offload-banner__close {
+.tc-offload-banner__body { flex: 1; }
+.tc-offload-banner__close {
     cursor: pointer;
     opacity: 0.5;
     padding: 0 0 0 10px;
     font-size: 18px;
     line-height: 1;
-    flex-shrink: 0;
 }
-
-.tm-offload-ul {
+.tc-offload-ul {
     margin: 4px 0 4px 18px;
     padding: 0;
 }
 
-/* ── Action / rate-limit panel ────────────────────────────────────── */
-.tm-rate-panel {
-    padding: 12px 14px;
-    border-radius: 8px;
-    margin-bottom: 8px;
-    border: 1px solid var(--tm-border);
-    background: var(--tm-section-action);
-}
-
-.tm-rate-panel__header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 8px;
-}
-
-.tm-rate-panel__title {
-    font-size: 12px;
-    font-weight: 600;
-    color: var(--tm-text);
-}
-
-/* ── Rate / mode segmented toggle inside rate panel ──────────────── */
-.tm-mode-toggle {
-    display: inline-flex;
-    border-radius: 8px;
-    overflow: hidden;
-    border: 1.5px solid var(--tm-border);
-    margin-top: 6px;
-}
-
-/* ── Custom-value row ─────────────────────────────────────────────── */
-.tm-custom-row {
-    display: flex;
-    margin-top: 6px;
-    align-items: center;
-    gap: 6px;
-}
-
-.tm-custom-input {
-    width: 70px;
-    font-size: 12px;
-    padding: 4px 8px;
-    border: 1.5px solid var(--tm-border);
-    border-radius: 8px;
-    background: var(--tm-bg);
-    color: var(--tm-text);
-}
-
-.tm-custom-unit-btns {
-    display: inline-flex;
-    border-radius: 8px;
-    overflow: hidden;
-    border: 1.5px solid var(--tm-border);
-}
-
-.tm-custom-apply {
-    padding: 4px 12px;
-    font-size: 12px;
-    border-radius: 8px;
-    border: none;
-    background: var(--tm-proto);
-    color: #fff;
-    cursor: pointer;
-    font-weight: 600;
-}
-
-/* ── Buttons (base + variants) ───────────────────────────────────── */
-.tm-btn {
-    padding: 5px 14px;
-    border-radius: 3px;
-    cursor: pointer;
-    font-size: 13px;
-    min-width: 140px;
-    text-align: center;
-    font-weight: 500;
-    color: #fff;
-}
-
-.tm-btn--block {
-    background: #c05621;
-    border: 1px solid #9c4221;
-}
-
-.tm-btn--unblock {
-    background: #276749;
-    border: 1px solid #22543d;
-}
-
-/* ── Action row (inet + wifi buttons) ────────────────────────────── */
-.tm-action-row {
+/* ── Action row (block / wifi buttons) ───────────────────────────── */
+.tc-action-row {
     display: flex;
     flex-wrap: nowrap;
     align-items: center;
     gap: 8px;
 }
 
-/* ── Settings panel ──────────────────────────────────────────────── */
-.tm-settings-panel {
-    border-radius: 8px;
-    margin-bottom: 10px;
-    background: var(--tm-section-action);
-    border: 1px solid var(--tm-border);
+/* ── Rate / mode panel ────────────────────────────────────────────── */
+.tc-rate-panel {
+    padding: 12px 14px;
+    border-radius: 4px;
+    margin-bottom: 8px;
+    border: 1px solid var(--tc-border);
+    background: var(--tc-bg-alt);
 }
-
-.tm-settings-toggle {
-    padding: 8px 14px;
-    cursor: pointer;
-    user-select: none;
+.tc-rate-panel__header {
     display: flex;
     align-items: center;
-    gap: 6px;
-    font-size: 12px;
-    font-weight: 600;
-    color: var(--tm-text-mute);
-}
-
-.tm-settings-body {
-    padding: 0 14px 10px;
-}
-
-/* ── Status bar ──────────────────────────────────────────────────── */
-.tm-status {
-    padding: 8px 14px;
-    border-radius: 4px;
-    font-size: 13px;
-    margin-bottom: 10px;
-}
-
-.tm-status--loading {
-    background: var(--tm-info-bg);
-    border: 1px solid var(--tm-info-border);
-    color: var(--tm-info-fg);
-}
-
-.tm-status--ok {
-    background: var(--tm-info-bg);
-    border: 1px solid var(--tm-state-ok);
-    color: var(--tm-state-ok);
-}
-
-.tm-status--error {
-    background: var(--tm-blocked-bg);
-    border: 1px solid var(--tm-blocked-border);
-    color: var(--tm-blocked-fg);
-}
-
-.tm-status--action {
-    background: var(--tm-info-bg);
-    border: 1px solid var(--tm-rate-fg);
-    color: var(--tm-rate-fg);
-}
-
-/* ── Stats bar (summary / single device) ─────────────────────────── */
-.tm-stats-bar {
-    padding: 8px 14px;
-    border-radius: 4px;
-    font-size: 13px;
+    justify-content: space-between;
     margin-bottom: 8px;
 }
-
-.tm-stats-bar--info {
-    background: var(--tm-info-bg);
-    border: 1px solid var(--tm-info-border);
-    color: var(--tm-info-fg);
+.tc-rate-panel__title {
+    font-size: 12px;
+    font-weight: 600;
 }
 
-.tm-stats-bar--blocked {
-    background: var(--tm-blocked-bg);
-    border: 1px solid var(--tm-blocked-border);
-    color: var(--tm-blocked-fg);
+/* ── Mode toggle (segmented) ─────────────────────────────────────── */
+.tc-mode-toggle {
+    display: inline-flex;
+    border-radius: 4px;
+    overflow: hidden;
+    border: 1px solid var(--tc-border);
+    margin-top: 6px;
 }
 
-/* ── Chip base (shared by all chip variants) ─────────────────────── */
-.tm-chip {
+/* ── Custom rate input row ───────────────────────────────────────── */
+.tc-custom-row {
+    display: flex;
+    margin-top: 6px;
+    align-items: center;
+    gap: 6px;
+}
+.tc-custom-input {
+    width: 70px;
+    font-size: 12px;
+    padding: 4px 8px;
+    border: 1px solid var(--tc-border);
+    border-radius: 4px;
+    background: var(--tc-bg);
+    color: inherit;
+}
+.tc-custom-unit-btns {
+    display: inline-flex;
+    border-radius: 4px;
+    overflow: hidden;
+    border: 1px solid var(--tc-border);
+}
+
+/* ── Chips (rate preset pills) ───────────────────────────────────── */
+.tc-chip {
     display: inline-block;
-    padding: 4px 10px;
+    padding: 3px 10px;
     margin: 2px;
     border-radius: 14px;
     font-size: 12px;
     font-weight: 500;
     cursor: pointer;
     transition: all .15s;
-    border: 1.5px solid var(--tm-border);
-    background: var(--tm-bg);
-    color: var(--tm-text);
+    border: 1px solid var(--tc-border);
+    background: var(--tc-bg);
+    color: inherit;
     user-select: none;
 }
-
-.tm-chip--active {
-    border-color: var(--tm-proto);
-    background: var(--tm-proto);
+.tc-chip--active {
+    border-color: var(--tc-speed);
+    background: var(--tc-speed);
     color: #fff;
     font-weight: 600;
 }
-
-.tm-chip--off {
-    color: var(--tm-text-mute);
-}
-
-.tm-chip--off-active {
-    border-color: var(--tm-text-mute);
-    background: var(--tm-text-mute);
-    color: #fff;
-    font-weight: 600;
-}
-
-/* ── Rate chips row ──────────────────────────────────────────────── */
-.tm-rate-chips-row {
+.tc-chips-row {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
@@ -257,10 +207,10 @@
 }
 
 /* ── Column visibility chips ─────────────────────────────────────── */
-.tm-col-chip {
+.tc-col-chip {
     display: inline-block;
-    padding: 3px 10px;
-    border-radius: 12px;
+    padding: 2px 8px;
+    border-radius: 10px;
     font-size: 11px;
     cursor: pointer;
     user-select: none;
@@ -268,561 +218,371 @@
     transition: all .15s;
     font-weight: 500;
 }
+.tc-col-chip--on  { background: var(--tc-speed); color: #fff; border: 1px solid var(--tc-speed); }
+.tc-col-chip--off { background: var(--tc-bg); color: var(--tc-muted); border: 1px solid var(--tc-border); }
 
-.tm-col-chip--on {
-    background: var(--tm-proto);
-    color: #fff;
-    border: 1px solid var(--tm-proto);
+/* ── Settings panel (collapsible) ────────────────────────────────── */
+.tc-settings-panel {
+    border-radius: 4px;
+    margin-bottom: 10px;
+    background: var(--tc-bg-alt);
+    border: 1px solid var(--tc-border);
+}
+.tc-settings-toggle {
+    padding: 8px 14px;
+    cursor: pointer;
+    user-select: none;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--tc-muted);
+}
+.tc-settings-body {
+    padding: 0 14px 10px;
+}
+.tc-settings-section-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 6px;
+    padding-top: 4px;
+}
+.tc-divider {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--tc-muted);
+    margin-top: 12px;
+    margin-bottom: 6px;
+    padding-bottom: 4px;
+    border-bottom: 1px solid var(--tc-border);
 }
 
-.tm-col-chip--off {
-    background: var(--tm-bg);
-    color: var(--tm-text-mute);
-    border: 1px solid var(--tm-border);
-}
-
-/* ── Quick-bar (All devices + recent chips) ──────────────────────── */
-.tm-quick-bar {
+/* ── Quick bar (All + recent device chips) ───────────────────────── */
+.tc-quick-bar {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
     gap: 4px;
-    margin-top: 6px;
+    margin-bottom: 8px;
 }
-
-.tm-quick-bar__all {
+.tc-recent-chip {
     display: inline-flex;
     align-items: center;
     gap: 3px;
-    padding: 4px 10px;
-    border-radius: 14px;
-    font-size: 12px;
-    font-weight: 600;
-    cursor: pointer;
-    transition: all .15s;
-    user-select: none;
-    border: 1.5px solid var(--tm-proto);
-    background: var(--tm-proto);
-    color: #fff;
-}
-
-.tm-quick-bar__all--outline {
-    background: var(--tm-bg);
-    color: var(--tm-proto);
-}
-
-.tm-recent-container {
-    display: inline-flex;
-    flex-wrap: wrap;
-    gap: 4px;
-    align-items: center;
-}
-
-/* ── Recent device chips (base + active) ─────────────────────────── */
-.tm-recent-chip {
-    display: inline-flex;
-    align-items: center;
-    gap: 3px;
-    padding: 4px 10px;
-    border-radius: 14px;
+    padding: 3px 8px;
+    border-radius: 12px;
     font-size: 11px;
     font-weight: 500;
     cursor: pointer;
     transition: all .15s;
     user-select: none;
-    border: 1.5px solid var(--tm-border);
-    background: var(--tm-bg);
-    color: var(--tm-text);
+    border: 1px solid var(--tc-border);
+    background: var(--tc-bg);
 }
-
-.tm-recent-chip--active {
+.tc-recent-chip--active {
+    border-color: var(--tc-speed);
+    background: var(--tc-bg-alt);
+    color: var(--tc-speed);
     font-weight: 600;
-    border-color: var(--tm-proto);
-    background: var(--tm-info-bg);
-    color: var(--tm-proto);
 }
-
-.tm-recent-remove {
+.tc-recent-remove {
     margin-left: 2px;
     font-size: 10px;
     opacity: 0;
     transition: opacity .15s;
-    color: var(--tm-text-mute);
     cursor: pointer;
 }
+.tc-recent-chip:hover .tc-recent-remove { opacity: 0.5; }
 
-/* ── Toggle wrapper ──────────────────────────────────────────────── */
-.tm-toggle-wrap {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    margin-right: 12px;
-    white-space: nowrap;
-}
-
-/* ── Inline label (muted, small) ─────────────────────────────────── */
-.tm-inline-label {
-    font-size: 12px;
-    margin-right: 4px;
-    white-space: nowrap;
-    color: var(--tm-text-mute);
-}
-
-/* ── Inline pick display text ────────────────────────────────────── */
-.tm-inline-pick-display {
-    color: var(--tm-text);
-    font-size: 12px;
-    font-weight: 500;
-    cursor: pointer;
-    border-bottom: 1px dashed var(--tm-text-mute);
-    padding-bottom: 1px;
-    white-space: nowrap;
-}
-
-.tm-inline-pick-wrapper {
-    position: relative;
-    display: inline-block;
-}
-
-.tm-inline-pick-popup {
-    position: absolute;
-    top: calc(100% + 4px);
-    left: 50%;
-    transform: translateX(-50%);
-    background: var(--tm-bg);
-    border: 1px solid var(--tm-border);
-    border-radius: 6px;
-    box-shadow: 0 4px 12px rgba(0,0,0,.15);
-    z-index: 200;
-    padding: 4px 0;
-    white-space: nowrap;
-}
-
-/* ── Search select dropdown ──────────────────────────────────────── */
-.tm-search-wrapper {
+/* ── Search / device picker ──────────────────────────────────────── */
+.tc-search-wrapper {
     position: relative;
     display: inline-block;
     width: 100%;
     max-width: 480px;
 }
-
-.tm-search-input {
+.tc-search-input {
     width: 100%;
-    padding: 8px 32px 8px 12px;
+    padding: 7px 30px 7px 10px;
     font-size: 14px;
-    border: 2px solid var(--tm-border);
-    border-radius: 6px;
+    border: 1px solid var(--tc-border);
+    border-radius: 4px;
     cursor: pointer;
-    background: var(--tm-bg);
-    color: var(--tm-text);
+    background: var(--tc-bg);
+    color: inherit;
 }
-
-.tm-search-clear {
+.tc-search-clear {
     position: absolute;
     right: 8px;
     top: 50%;
     transform: translateY(-50%);
     cursor: pointer;
-    color: var(--tm-text-mute);
+    color: var(--tc-muted);
     font-size: 16px;
     line-height: 1;
 }
-
-.tm-search-dropdown {
+.tc-search-dropdown {
     position: absolute;
     top: 100%;
     left: 0;
     right: 0;
     max-height: 280px;
     overflow-y: auto;
-    background: var(--tm-bg);
-    border: 1px solid var(--tm-border);
+    background: var(--tc-bg);
+    border: 1px solid var(--tc-border);
     border-top: none;
     border-radius: 0 0 4px 4px;
     box-shadow: 0 4px 8px rgba(0,0,0,.15);
     z-index: 100;
 }
-
-.tm-dropdown-item {
+.tc-dropdown-item {
     padding: 6px 10px;
     cursor: pointer;
     font-size: 13px;
-    border-bottom: 1px solid var(--tm-border);
+    border-bottom: 1px solid var(--tc-border);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
 }
-
-.tm-dropdown-item--section {
+.tc-dropdown-item:hover { background: var(--tc-hover); }
+.tc-dropdown-item--section {
     padding: 3px 10px;
     font-size: 11px;
-    color: var(--tm-text-mute);
+    color: var(--tc-muted);
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: .3px;
     cursor: default;
-    border-bottom: 1px solid var(--tm-border);
+    border-bottom: 1px solid var(--tc-border);
 }
-
-.tm-dropdown-item--all {
+.tc-dropdown-item--all {
     font-weight: 600;
-    color: var(--tm-proto);
+    color: var(--tc-speed);
 }
 
 /* ── Speed graph popup ───────────────────────────────────────────── */
-.tm-graph-popup {
+.tc-graph-popup {
     position: fixed;
     z-index: 500;
     padding: 10px;
-    border-radius: 10px;
-    background: var(--tm-bg);
-    border: 1px solid var(--tm-border);
-    box-shadow: 0 8px 24px rgba(0,0,0,.25);
+    border-radius: 6px;
+    background: var(--tc-bg);
+    border: 1px solid var(--tc-border);
+    box-shadow: 0 4px 16px rgba(0,0,0,.2);
 }
-
-.tm-graph-popup__note {
+.tc-graph-popup__note {
     font-size: 10px;
-    color: var(--tm-text-mute);
+    color: var(--tc-faint);
     margin-top: 4px;
     text-align: center;
 }
-
-.tm-graph-popup__empty {
-    color: var(--tm-text-mute);
+.tc-graph-popup__empty {
+    color: var(--tc-muted);
     font-size: 11px;
 }
 
-/* ── Extended stats panel (base + sticky) ────────────────────────── */
-.tm-ext-panel {
-    background: var(--tm-bg-subtle);
-    border: 1px solid var(--tm-border);
+/* ── Extended stats panel ────────────────────────────────────────── */
+.tc-ext-panel {
+    border: 1px solid var(--tc-border);
     border-radius: 4px;
-    padding: 12px 16px;
+    padding: 10px 14px;
     font-size: 13px;
     margin: 8px 0;
+    background: var(--tc-bg-alt);
 }
-
-.tm-ext-panel--sticky {
-    position: sticky;
-    top: 0;
-}
-
-.tm-ext-panel__title {
+.tc-ext-panel__title {
     margin-bottom: 8px;
     font-weight: 600;
     font-size: 14px;
-    color: var(--tm-text);
 }
-
-.tm-ext-row {
+.tc-ext-row {
     display: flex;
     justify-content: space-between;
     align-items: baseline;
-    padding: 4px 0;
-    border-bottom: 1px dotted var(--tm-border);
+    padding: 3px 0;
+    border-bottom: 1px dotted var(--tc-border);
 }
 
-.tm-ext-col-flex {
-    display: flex;
-    flex-direction: column;
-}
-
-/* ── Activity log panel ──────────────────────────────────────────── */
-.tm-activity-panel {
-    margin: 8px 0;
-    padding: 8px 14px;
-    border-radius: 4px;
-    border: 1px solid var(--tm-border);
-    background: var(--tm-bg-subtle);
-}
-
-.tm-log-area {
+/* ── Activity log ────────────────────────────────────────────────── */
+.tc-log-area {
     max-height: 250px;
     overflow-y: auto;
     font-family: monospace;
     font-size: 11px;
-    background: var(--tm-bg);
-    border: 1px solid var(--tm-border);
+    background: var(--tc-bg);
+    border: 1px solid var(--tc-border);
     border-radius: 4px;
     padding: 6px;
     white-space: pre-wrap;
     word-break: break-all;
-    color: var(--tm-text);
 }
-
-.tm-log-line {
+.tc-log-line {
     padding: 1px 0;
-    border-bottom: 1px solid var(--tm-border);
+    border-bottom: 1px solid var(--tc-border);
 }
 
-/* ── Tables ──────────────────────────────────────────────────────── */
-.tm-table {
-    width: 100%;
-    border-collapse: collapse;
-    font-size: 12px;
-    border: 1px solid var(--tm-border);
-    border-radius: 4px;
-    overflow: hidden;
-}
-
-.tm-th {
-    cursor: pointer;
-    padding: 7px 12px;
-    white-space: nowrap;
-    background: var(--tm-th-bg);
-    color: var(--tm-th-fg);
-    border: none;
-    font-size: 12px;
-    font-weight: 600;
-    user-select: none;
-    text-align: left;
-}
-
-/* ── Table cell base + utilities ─────────────────────────────────── */
-.tm-td {
-    padding: 6px 12px;
-    border-bottom: 1px solid var(--tm-border);
-    font-size: 12px;
-    color: var(--tm-text);
-}
-
-.tm-td--compact { padding: 5px 12px; }
-.tm-td--mono    { font-family: monospace; }
-.tm-td--right   { text-align: right; }
-.tm-td--center  { text-align: center; }
-.tm-td--bold    { font-weight: 600; }
-.tm-td--medium  { font-weight: 500; }
-.tm-td--sm      { font-size: 11px; }
-
-/* Row striping via nth-child (replaces inline background) */
-.tm-row:nth-child(odd) > .tm-td  { background: var(--tm-bg); }
-.tm-row:nth-child(even) > .tm-td { background: var(--tm-bg-alt); }
-
-/* ── Color utilities (for td, span, b) ──────────────────────────── */
-.tm-c-proto  { color: var(--tm-proto); }
-.tm-c-service { color: var(--tm-service); }
-.tm-c-ok     { color: var(--tm-state-ok); }
-.tm-c-wait   { color: var(--tm-state-wait); }
-.tm-c-close  { color: var(--tm-state-close); }
-.tm-c-rate   { color: var(--tm-rate-fg); }
-.tm-c-shape  { color: var(--tm-shape-fg); }
-.tm-c-drop   { color: var(--tm-drop-fg); }
-.tm-c-mute   { color: var(--tm-text-mute); }
-.tm-c-faint  { color: var(--tm-text-faint); }
-.tm-c-speed  { color: var(--tm-speed); }
-.tm-fw-600   { font-weight: 600; }
-.tm-fw-500   { font-weight: 500; }
-
-/* ── Device icon wrapper ─────────────────────────────────────────── */
-.tm-device-icon-wrap {
-    position: relative;
-}
-
-.tm-device-icon-badge {
-    position: absolute;
-    top: -2px;
-    right: -8px;
-    font-size: 8px;
-}
-
-/* ── Card grid ───────────────────────────────────────────────────── */
-.tm-card-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-    gap: 8px;
-    margin-bottom: 8px;
-}
-
-/* ── Card (base + all variant) ───────────────────────────────────── */
-.tm-card {
-    padding: 10px 8px;
-    border-radius: 8px;
-    border: 2px solid var(--tm-border);
-    background: var(--tm-bg);
-    cursor: pointer;
-    text-align: center;
-    font-size: 11px;
-    transition: all .15s;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 3px;
-    overflow: hidden;
-}
-
-.tm-card--all {
-    padding: 10px;
-    border-color: var(--tm-proto);
-    background: var(--tm-info-bg);
-    font-size: 12px;
-    font-weight: 600;
-    color: var(--tm-proto);
-    gap: 4px;
-}
-
-.tm-card__name {
-    font-weight: 600;
-    color: var(--tm-text);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 100%;
-}
-
-.tm-card__ip {
-    color: var(--tm-text-mute);
-    font-family: monospace;
-    font-size: 10px;
-}
-
-.tm-card__speed {
-    color: var(--tm-speed);
-    font-weight: 600;
-    font-size: 10px;
-}
-
-/* ── Avatar strip ────────────────────────────────────────────────── */
-.tm-avatar-strip {
-    display: flex;
-    gap: 6px;
-    overflow-x: auto;
-    padding: 6px 2px;
-    margin-bottom: 8px;
-    scrollbar-width: thin;
-}
-
-.tm-avatar-pill {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 2px;
-    cursor: pointer;
-    min-width: 56px;
-    transition: all .15s;
-}
-
-/* ── Chip cloud (device selector) ────────────────────────────────── */
-.tm-chip-cloud {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 4px;
-    margin-bottom: 8px;
-    align-items: center;
-}
-
-/* ── Cloud chip (base + variants) ────────────────────────────────── */
-.tm-cloud-chip {
+/* ── Inline label / toggle layout ────────────────────────────────── */
+.tc-toggle-wrap {
     display: inline-flex;
     align-items: center;
-    gap: 4px;
-    padding: 5px 10px;
-    border-radius: 16px;
+    gap: 6px;
+    margin-right: 12px;
+    white-space: nowrap;
+}
+.tc-inline-label {
     font-size: 12px;
-    cursor: pointer;
-    transition: all .15s;
-    border: 1.5px solid var(--tm-border);
-    background: var(--tm-bg);
-    color: var(--tm-text);
-    user-select: none;
+    margin-right: 4px;
+    white-space: nowrap;
+    color: var(--tc-muted);
 }
-
-.tm-cloud-chip--active {
-    border-color: var(--tm-proto);
-    background: var(--tm-proto);
-    color: #fff;
-    font-weight: 600;
-}
-
-.tm-cloud-chip--blocked {
-    border-color: var(--tm-blocked-border);
-    background: var(--tm-blocked-bg);
-    color: var(--tm-blocked-fg);
-}
-
-.tm-cloud-chip--limited {
-    border-color: var(--tm-rate-fg);
-    color: var(--tm-rate-fg);
-}
-
-.tm-cloud-chip__speed {
-    font-size: 10px;
-    opacity: .7;
-}
-
-/* ── Section label ───────────────────────────────────────────────── */
-.tm-section-label {
-    font-size: 12px;
-    font-weight: 600;
-    color: var(--tm-text-mute);
-    margin-bottom: 4px;
-    margin-top: 8px;
-}
-
-/* ── Separator (vertical pipe) ───────────────────────────────────── */
-.tm-sep {
-    border-left: 1px solid var(--tm-border);
+.tc-sep {
+    border-left: 1px solid var(--tc-border);
     height: 18px;
     margin: 0 4px;
+    display: inline-block;
+    vertical-align: middle;
 }
 
+/* ── Toggle switch ───────────────────────────────────────────────── */
+.tc-toggle-input { position: absolute; opacity: 0; width: 0; height: 0; }
+.tc-toggle {
+    position: relative; display: inline-block;
+    width: 34px; height: 18px;
+    background: var(--tc-border);
+    border-radius: 9px; cursor: pointer; transition: background .2s;
+}
+.tc-toggle::after {
+    content: ""; position: absolute;
+    top: 2px; left: 2px;
+    width: 14px; height: 14px;
+    background: #fff; border-radius: 50%;
+    transition: transform .2s; box-shadow: 0 1px 2px rgba(0,0,0,.2);
+}
+.tc-toggle-input:checked + .tc-toggle { background: var(--tc-speed); }
+.tc-toggle-input:checked + .tc-toggle::after { transform: translateX(16px); }
+
+/* ── Tooltip ─────────────────────────────────────────────────────── */
+[data-tip] { position: relative; }
+[data-tip]::after {
+    content: attr(data-tip);
+    position: absolute; bottom: calc(100% + 4px); left: 50%;
+    transform: translateX(-50%);
+    padding: 4px 8px; border-radius: 4px;
+    font-size: 11px; font-weight: 400; white-space: nowrap;
+    background: #2d3748; color: #fff;
+    pointer-events: none; opacity: 0; transition: opacity .1s; z-index: 999;
+}
+[data-tip]:hover::after { opacity: 1; }
+
 /* ── Version footer ──────────────────────────────────────────────── */
-.tm-version-footer {
+.tc-version-footer {
     text-align: right;
     font-size: 10px;
-    color: var(--tm-text-faint);
+    color: var(--tc-faint);
     padding: 8px 4px 0;
     user-select: all;
 }
 
-/* ── SVG inline icon (Ethernet) ──────────────────────────────────── */
-.tm-eth-icon {
-    display: inline-block;
-    vertical-align: middle;
-    margin-right: 3px;
+/* ── Ethernet SVG icon ───────────────────────────────────────────── */
+.tc-eth-icon { display: inline-block; vertical-align: middle; margin-right: 3px; }
+
+/* ── Inline pick (poll interval etc.) ───────────────────────────── */
+.tc-inline-pick-display {
+    color: inherit;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    border-bottom: 1px dashed var(--tc-muted);
+    padding-bottom: 1px;
+    white-space: nowrap;
+}
+.tc-inline-pick-wrapper { position: relative; display: inline-block; }
+.tc-inline-pick-popup {
+    position: absolute;
+    top: calc(100% + 4px); left: 50%;
+    transform: translateX(-50%);
+    background: var(--tc-bg);
+    border: 1px solid var(--tc-border);
+    border-radius: 4px;
+    box-shadow: 0 4px 12px rgba(0,0,0,.15);
+    z-index: 200; padding: 4px 0; white-space: nowrap;
 }
 
-/* ── Settings subsections ────────────────────────────────────────── */
-.tm-settings-section-row {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 6px;
-    padding-top: 4px;
+/* ── Telegram settings section ───────────────────────────────────── */
+.tg-section  { border-left: 3px solid #0088cc; padding-left: 12px; margin-top: 4px; }
+.tg-row      { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; }
+.tg-row + .tg-row { margin-top: 8px; }
+.tg-input {
+    font-size: 12px; padding: 4px 8px;
+    background: var(--tc-bg); color: inherit;
+    border: 1px solid var(--tc-border); border-radius: 4px;
+    outline: none; transition: border-color .2s;
+}
+.tg-input:focus { border-color: #0088cc; }
+.tg-input--token    { width: 240px; }
+.tg-input--chat     { width: 120px; }
+.tg-input--template { width: 100%; min-height: 60px; resize: vertical; font-family: monospace; font-size: 11px; }
+.tg-btn {
+    font-size: 11px; padding: 3px 10px;
+    border: 1px solid var(--tc-border); border-radius: 4px;
+    background: var(--tc-bg); color: inherit;
+    cursor: pointer; transition: background .15s;
+}
+.tg-btn:hover { background: var(--tc-hover); }
+.tg-btn--primary { background: #0088cc; color: #fff; border-color: #0088cc; }
+.tg-btn--primary:hover { background: #006fa3; }
+.tg-label      { font-size: 11px; color: var(--tc-muted); font-weight: 500; }
+.tg-status-dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-left: 6px; vertical-align: middle; }
+.tg-status-dot--on  { background: var(--tc-ok); }
+.tg-status-dot--off { background: var(--tc-faint); }
+.tg-segmented { display: inline-flex; border: 1px solid var(--tc-border); border-radius: 4px; overflow: hidden; font-size: 12px; }
+.tg-segmented__item {
+    padding: 5px 14px; cursor: pointer;
+    background: var(--tc-bg); color: var(--tc-muted);
+    transition: background .15s, color .15s; user-select: none;
+    border-right: 1px solid var(--tc-border);
+    border-top: none; border-bottom: none; border-left: none;
+    font-family: inherit; font-size: inherit; line-height: inherit; outline: none;
+}
+.tg-segmented__item:last-child { border-right: none; }
+.tg-segmented__item--active { background: #0088cc; color: #fff; }
+.tg-divider { font-size: 11px; font-weight: 600; color: var(--tc-muted); margin-top: 12px; margin-bottom: 6px; padding-bottom: 4px; border-bottom: 1px solid var(--tc-border); }
+.tg-bubble { background: var(--tc-bg-alt); border: 1px solid var(--tc-border); border-radius: 12px 12px 12px 4px; padding: 10px 14px; max-width: 280px; font-size: 12px; line-height: 1.5; box-shadow: 0 1px 2px rgba(0,0,0,0.06); }
+.tg-bubble--kbd { text-align: center; border-radius: 12px; }
+.tg-kbd-row { display: flex; gap: 2px; justify-content: center; margin-top: 4px; }
+.tg-kbd-btn { background: #3390ec; color: #fff; border-radius: 6px; padding: 5px 10px; font-size: 11px; flex: 1; text-align: center; min-width: 0; }
+.tg-commands { background: var(--tc-bg-alt); border: 1px solid var(--tc-border); border-radius: 4px; padding: 8px 12px; font-family: monospace; font-size: 11px; line-height: 1.8; }
+.tg-eye { cursor: pointer; font-size: 14px; user-select: none; line-height: 1; }
+.tg-template-hint { font-size: 10px; color: var(--tc-faint); margin-top: 2px; }
+.tg-save-status { font-size: 11px; margin-left: 8px; transition: opacity .3s; }
+
+/* ── Spinner ─────────────────────────────────────────────────────── */
+@keyframes tc-spin { to { transform: rotate(360deg); } }
+.tc-spinner {
+    display: inline-block; width: 14px; height: 14px;
+    border: 2px solid var(--tc-border);
+    border-top-color: inherit;
+    border-radius: 50%;
+    animation: tc-spin .7s linear infinite;
+    vertical-align: middle; margin-right: 6px;
 }
 
-.tm-conn-filters-row {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 6px;
-    margin-bottom: 6px;
-}
+/* ── Link style ──────────────────────────────────────────────────── */
+.tc-link { color: inherit; text-decoration: none; border-bottom: 1px dotted var(--tc-faint); }
+.tc-link:hover { border-bottom-style: solid; }
 
-.tm-table-speed-inner {
-    padding-top: 4px;
+/* ── Conn filter row ─────────────────────────────────────────────── */
+.tc-conn-filters-row {
+    display: flex; flex-wrap: wrap; align-items: center;
+    gap: 6px; margin-bottom: 6px;
 }
-
-.tm-table-speed-row {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 6px;
-    margin-bottom: 8px;
+.tc-table-speed-row {
+    display: flex; flex-wrap: wrap; align-items: center;
+    gap: 6px; margin-bottom: 8px;
 }
-
-/* ── Logging section row ─────────────────────────────────────────── */
-.tm-log-row {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 6px;
-    padding-top: 4px;
-}
-
-/* ── Chips container ─────────────────────────────────────────────── */
-.tm-chips-wrap {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0;
+.tc-log-row {
+    display: flex; flex-wrap: wrap; align-items: center;
+    gap: 6px; padding-top: 4px;
 }

--- a/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.css
+++ b/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.css
@@ -384,6 +384,15 @@
 }
 
 /* ── Extended stats panel ────────────────────────────────────────── */
+.tc-device-graph {
+    margin: 8px 0;
+    border: 1px solid var(--tc-border);
+    border-radius: 6px;
+    overflow: hidden;
+    background: var(--tc-bg-alt);
+}
+.tc-device-graph svg { display: block; width: 100%; }
+
 .tc-ext-panel {
     border: 1px solid var(--tc-border);
     border-radius: 4px;

--- a/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.js
+++ b/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.js
@@ -234,7 +234,7 @@ function mkEthIcon(size) {
 	svg.setAttribute('stroke-width', '2');
 	svg.setAttribute('stroke-linecap', 'round');
 	svg.setAttribute('stroke-linejoin', 'round');
-	svg.setAttribute('class', 'tm-eth-icon');
+	svg.setAttribute('class', 'tc-eth-icon');
 	var path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
 	path.setAttribute('d', 'M4 7h16a1 1 0 0 1 1 1v8a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V8a1 1 0 0 1 1-1zM7 11v2M10 11v2M13 11v2M16 11v2');
 	svg.appendChild(path);
@@ -260,7 +260,7 @@ function renderSparkline(history, globalMax, width, height, limitKbit) {
 	svg.style.cssText = 'display:block;margin:0 auto'; /* sparkline — kept inline (runtime/canvas) */
 	var area = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
 	area.setAttribute('points', '0,' + h + ' ' + points.join(' ') + ' ' + (w - 0) + ',' + h);
-	area.setAttribute('fill', 'var(--tm-speed)');
+	area.setAttribute('fill', 'var(--tc-speed)');
 	area.setAttribute('opacity', '0.1');
 	area.setAttribute('stroke', 'none');
 	svg.appendChild(area);
@@ -272,7 +272,7 @@ function renderSparkline(history, globalMax, width, height, limitKbit) {
 			var line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
 			line.setAttribute('x1', '0'); line.setAttribute('x2', String(w));
 			line.setAttribute('y1', ly); line.setAttribute('y2', ly);
-			line.setAttribute('stroke', 'var(--tm-rate-fg)');
+			line.setAttribute('stroke', 'var(--tc-warn)');
 			line.setAttribute('stroke-width', '1');
 			line.setAttribute('stroke-dasharray', '3,2');
 			line.setAttribute('opacity', '0.7');
@@ -282,7 +282,7 @@ function renderSparkline(history, globalMax, width, height, limitKbit) {
 	var polyline = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');
 	polyline.setAttribute('points', points.join(' '));
 	polyline.setAttribute('fill', 'none');
-	polyline.setAttribute('stroke', 'var(--tm-speed)');
+	polyline.setAttribute('stroke', 'var(--tc-speed)');
 	polyline.setAttribute('stroke-width', '1.5');
 	polyline.setAttribute('stroke-linejoin', 'round');
 	svg.appendChild(polyline);
@@ -351,9 +351,9 @@ function renderFullGraph(history, limitKbit, width, height) {
 	grad.setAttribute('id', 'fg-dl-grad'); grad.setAttribute('x1', '0'); grad.setAttribute('y1', '0');
 	grad.setAttribute('x2', '0'); grad.setAttribute('y2', '1');
 	var stop1 = document.createElementNS(ns, 'stop');
-	stop1.setAttribute('offset', '0%'); stop1.setAttribute('stop-color', 'var(--tm-speed)'); stop1.setAttribute('stop-opacity', '0.35');
+	stop1.setAttribute('offset', '0%'); stop1.setAttribute('stop-color', 'var(--tc-speed)'); stop1.setAttribute('stop-opacity', '0.35');
 	var stop2 = document.createElementNS(ns, 'stop');
-	stop2.setAttribute('offset', '100%'); stop2.setAttribute('stop-color', 'var(--tm-speed)'); stop2.setAttribute('stop-opacity', '0.03');
+	stop2.setAttribute('offset', '100%'); stop2.setAttribute('stop-color', 'var(--tc-speed)'); stop2.setAttribute('stop-opacity', '0.03');
 	grad.appendChild(stop1); grad.appendChild(stop2); defs.appendChild(grad);
 
 	// Gradient for upload area
@@ -361,16 +361,16 @@ function renderFullGraph(history, limitKbit, width, height) {
 	gradUp.setAttribute('id', 'fg-ul-grad'); gradUp.setAttribute('x1', '0'); gradUp.setAttribute('y1', '0');
 	gradUp.setAttribute('x2', '0'); gradUp.setAttribute('y2', '1');
 	var stopU1 = document.createElementNS(ns, 'stop');
-	stopU1.setAttribute('offset', '0%'); stopU1.setAttribute('stop-color', 'var(--tm-state-ok)'); stopU1.setAttribute('stop-opacity', '0.25');
+	stopU1.setAttribute('offset', '0%'); stopU1.setAttribute('stop-color', 'var(--tc-ok)'); stopU1.setAttribute('stop-opacity', '0.25');
 	var stopU2 = document.createElementNS(ns, 'stop');
-	stopU2.setAttribute('offset', '100%'); stopU2.setAttribute('stop-color', 'var(--tm-state-ok)'); stopU2.setAttribute('stop-opacity', '0.02');
+	stopU2.setAttribute('offset', '100%'); stopU2.setAttribute('stop-color', 'var(--tc-ok)'); stopU2.setAttribute('stop-opacity', '0.02');
 	gradUp.appendChild(stopU1); gradUp.appendChild(stopU2); defs.appendChild(gradUp);
 	svg.appendChild(defs);
 
 	// Background
 	var bg = document.createElementNS(ns, 'rect');
 	bg.setAttribute('width', w); bg.setAttribute('height', h);
-	bg.setAttribute('fill', 'var(--tm-bg)'); bg.setAttribute('rx', '8');
+	bg.setAttribute('fill', 'var(--tc-bg)'); bg.setAttribute('rx', '8');
 	svg.appendChild(bg);
 
 	// Grid lines — nice tick values, at least 5 lines, label every 2nd if crowded
@@ -381,14 +381,14 @@ function renderFullGraph(history, limitKbit, width, height) {
 		var gl = document.createElementNS(ns, 'line');
 		gl.setAttribute('x1', pad.left); gl.setAttribute('x2', w - pad.right);
 		gl.setAttribute('y1', gy.toFixed(1)); gl.setAttribute('y2', gy.toFixed(1));
-		gl.setAttribute('stroke', 'var(--tm-border)'); gl.setAttribute('stroke-width', '0.5');
+		gl.setAttribute('stroke', 'var(--tc-border)'); gl.setAttribute('stroke-width', '0.5');
 		gl.setAttribute('stroke-dasharray', '2,2');
 		svg.appendChild(gl);
 		if (gi > 0 && gi % labelEvery === 0) {
 			var lbl = document.createElementNS(ns, 'text');
 			lbl.setAttribute('x', pad.left - 4); lbl.setAttribute('y', (gy + 3).toFixed(1));
 			lbl.setAttribute('text-anchor', 'end');
-			lbl.setAttribute('font-size', '9'); lbl.setAttribute('fill', 'var(--tm-text-mute)');
+			lbl.setAttribute('font-size', '9'); lbl.setAttribute('fill', 'var(--tc-muted)');
 			lbl.textContent = fmtSpeed(val);
 			svg.appendChild(lbl);
 		}
@@ -402,7 +402,7 @@ function renderFullGraph(history, limitKbit, width, height) {
 		var tl = document.createElementNS(ns, 'text');
 		tl.setAttribute('x', tx.toFixed(1)); tl.setAttribute('y', (h - 8).toFixed(1));
 		tl.setAttribute('text-anchor', 'middle');
-		tl.setAttribute('font-size', '9'); tl.setAttribute('fill', 'var(--tm-text-mute)');
+		tl.setAttribute('font-size', '9'); tl.setAttribute('fill', 'var(--tc-muted)');
 		if (secs < 60) tl.textContent = secs + 's';
 		else tl.textContent = Math.floor(secs/60) + 'm' + (secs%60 ? (secs%60)+'s' : '');
 		svg.appendChild(tl);
@@ -410,7 +410,7 @@ function renderFullGraph(history, limitKbit, width, height) {
 		var vtick = document.createElementNS(ns, 'line');
 		vtick.setAttribute('x1', tx.toFixed(1)); vtick.setAttribute('x2', tx.toFixed(1));
 		vtick.setAttribute('y1', pad.top); vtick.setAttribute('y2', pad.top + gh);
-		vtick.setAttribute('stroke', 'var(--tm-border)'); vtick.setAttribute('stroke-width', '0.3');
+		vtick.setAttribute('stroke', 'var(--tc-border)'); vtick.setAttribute('stroke-width', '0.3');
 		vtick.setAttribute('stroke-dasharray', '2,4');
 		svg.appendChild(vtick);
 	}
@@ -427,7 +427,7 @@ function renderFullGraph(history, limitKbit, width, height) {
 		bandPath += ' Z';
 		var bandEl = document.createElementNS(ns, 'path');
 		bandEl.setAttribute('d', bandPath);
-		bandEl.setAttribute('fill', 'var(--tm-speed)'); bandEl.setAttribute('opacity', '0.08');
+		bandEl.setAttribute('fill', 'var(--tc-speed)'); bandEl.setAttribute('opacity', '0.08');
 		svg.appendChild(bandEl);
 	}
 
@@ -442,7 +442,7 @@ function renderFullGraph(history, limitKbit, width, height) {
 	// Download line
 	var dlLine = document.createElementNS(ns, 'polyline');
 	dlLine.setAttribute('points', dlPoints.join(' '));
-	dlLine.setAttribute('fill', 'none'); dlLine.setAttribute('stroke', 'var(--tm-speed)');
+	dlLine.setAttribute('fill', 'none'); dlLine.setAttribute('stroke', 'var(--tc-speed)');
 	dlLine.setAttribute('stroke-width', '2'); dlLine.setAttribute('stroke-linejoin', 'round'); dlLine.setAttribute('stroke-linecap', 'round');
 	svg.appendChild(dlLine);
 
@@ -456,7 +456,7 @@ function renderFullGraph(history, limitKbit, width, height) {
 		svg.appendChild(ulArea);
 		var ulLine = document.createElementNS(ns, 'polyline');
 		ulLine.setAttribute('points', ulPoints.join(' '));
-		ulLine.setAttribute('fill', 'none'); ulLine.setAttribute('stroke', 'var(--tm-state-ok)');
+		ulLine.setAttribute('fill', 'none'); ulLine.setAttribute('stroke', 'var(--tc-ok)');
 		ulLine.setAttribute('stroke-width', '1.5'); ulLine.setAttribute('stroke-linejoin', 'round');
 		ulLine.setAttribute('stroke-dasharray', '4,2'); ulLine.setAttribute('opacity', '0.8');
 		svg.appendChild(ulLine);
@@ -468,7 +468,7 @@ function renderFullGraph(history, limitKbit, width, height) {
 		var ll = document.createElementNS(ns, 'line');
 		ll.setAttribute('x1', pad.left); ll.setAttribute('x2', w - pad.right);
 		ll.setAttribute('y1', ly.toFixed(1)); ll.setAttribute('y2', ly.toFixed(1));
-		ll.setAttribute('stroke', 'var(--tm-rate-fg)'); ll.setAttribute('stroke-width', '1.5');
+		ll.setAttribute('stroke', 'var(--tc-warn)'); ll.setAttribute('stroke-width', '1.5');
 		ll.setAttribute('stroke-dasharray', '6,3'); ll.setAttribute('opacity', '0.85');
 		svg.appendChild(ll);
 		// Label background
@@ -476,7 +476,7 @@ function renderFullGraph(history, limitKbit, width, height) {
 		var limLbl = document.createElementNS(ns, 'text');
 		limLbl.setAttribute('x', (w - pad.right - 3).toFixed(1)); limLbl.setAttribute('y', (ly - 5).toFixed(1));
 		limLbl.setAttribute('text-anchor', 'end');
-		limLbl.setAttribute('font-size', '9'); limLbl.setAttribute('fill', 'var(--tm-rate-fg)'); limLbl.setAttribute('font-weight', '600');
+		limLbl.setAttribute('font-size', '9'); limLbl.setAttribute('fill', 'var(--tc-warn)'); limLbl.setAttribute('font-weight', '600');
 		limLbl.textContent = '⚡ ' + limTxt;
 		svg.appendChild(limLbl);
 	}
@@ -487,14 +487,14 @@ function renderFullGraph(history, limitKbit, width, height) {
 	var dlLeg = document.createElementNS(ns, 'text');
 	dlLeg.setAttribute('x', legendX); dlLeg.setAttribute('y', legendY);
 	dlLeg.setAttribute('text-anchor', 'end'); dlLeg.setAttribute('font-size', '9');
-	dlLeg.setAttribute('fill', 'var(--tm-speed)'); dlLeg.setAttribute('font-weight', '600');
+	dlLeg.setAttribute('fill', 'var(--tc-speed)'); dlLeg.setAttribute('font-weight', '600');
 	dlLeg.textContent = '↓ DL';
 	svg.appendChild(dlLeg);
 	if (hasUpload) {
 		var ulLeg = document.createElementNS(ns, 'text');
 		ulLeg.setAttribute('x', legendX); ulLeg.setAttribute('y', legendY + 12);
 		ulLeg.setAttribute('text-anchor', 'end'); ulLeg.setAttribute('font-size', '9');
-		ulLeg.setAttribute('fill', 'var(--tm-state-ok)'); ulLeg.setAttribute('font-weight', '600');
+		ulLeg.setAttribute('fill', 'var(--tc-ok)'); ulLeg.setAttribute('font-weight', '600');
 		ulLeg.textContent = '↑ UL';
 		svg.appendChild(ulLeg);
 	}
@@ -505,12 +505,12 @@ function renderFullGraph(history, limitKbit, width, height) {
 	var lastY = yScale(lastP.speed);
 	var dot = document.createElementNS(ns, 'circle');
 	dot.setAttribute('cx', lastX.toFixed(1)); dot.setAttribute('cy', lastY.toFixed(1));
-	dot.setAttribute('r', '3.5'); dot.setAttribute('fill', 'var(--tm-speed)'); dot.setAttribute('stroke', 'var(--tm-bg)'); dot.setAttribute('stroke-width', '1.5');
+	dot.setAttribute('r', '3.5'); dot.setAttribute('fill', 'var(--tc-speed)'); dot.setAttribute('stroke', 'var(--tc-bg)'); dot.setAttribute('stroke-width', '1.5');
 	svg.appendChild(dot);
 	var curLbl = document.createElementNS(ns, 'text');
 	curLbl.setAttribute('x', (lastX - 6).toFixed(1)); curLbl.setAttribute('y', (lastY - 8).toFixed(1));
 	curLbl.setAttribute('text-anchor', 'end'); curLbl.setAttribute('font-size', '10');
-	curLbl.setAttribute('fill', 'var(--tm-speed)'); curLbl.setAttribute('font-weight', '700');
+	curLbl.setAttribute('fill', 'var(--tc-speed)'); curLbl.setAttribute('font-weight', '700');
 	curLbl.textContent = fmtSpeed(lastP.speed);
 	svg.appendChild(curLbl);
 
@@ -521,27 +521,27 @@ function renderFullGraph(history, limitKbit, width, height) {
 	overlay.setAttribute('fill', 'transparent'); overlay.setAttribute('style', 'cursor:crosshair');
 	var crossV = document.createElementNS(ns, 'line');
 	crossV.setAttribute('y1', pad.top); crossV.setAttribute('y2', pad.top + gh);
-	crossV.setAttribute('stroke', 'var(--tm-text-mute)'); crossV.setAttribute('stroke-width', '0.8');
+	crossV.setAttribute('stroke', 'var(--tc-muted)'); crossV.setAttribute('stroke-width', '0.8');
 	crossV.setAttribute('stroke-dasharray', '3,2'); crossV.setAttribute('display', 'none');
 	var crossH = document.createElementNS(ns, 'line');
 	crossH.setAttribute('x1', pad.left); crossH.setAttribute('x2', w - pad.right);
-	crossH.setAttribute('stroke', 'var(--tm-text-mute)'); crossH.setAttribute('stroke-width', '0.8');
+	crossH.setAttribute('stroke', 'var(--tc-muted)'); crossH.setAttribute('stroke-width', '0.8');
 	crossH.setAttribute('stroke-dasharray', '3,2'); crossH.setAttribute('display', 'none');
 	var crossDot = document.createElementNS(ns, 'circle');
-	crossDot.setAttribute('r', '4'); crossDot.setAttribute('fill', 'var(--tm-speed)');
+	crossDot.setAttribute('r', '4'); crossDot.setAttribute('fill', 'var(--tc-speed)');
 	crossDot.setAttribute('stroke', '#fff'); crossDot.setAttribute('stroke-width', '2'); crossDot.setAttribute('display', 'none');
 	var crossLabel = document.createElementNS(ns, 'text');
-	crossLabel.setAttribute('font-size', '10'); crossLabel.setAttribute('fill', 'var(--tm-text)');
+	crossLabel.setAttribute('font-size', '10'); crossLabel.setAttribute('fill', 'currentColor');
 	crossLabel.setAttribute('font-weight', '600'); crossLabel.setAttribute('display', 'none');
 	var crossTime = document.createElementNS(ns, 'text');
-	crossTime.setAttribute('font-size', '9'); crossTime.setAttribute('fill', 'var(--tm-text-mute)');
+	crossTime.setAttribute('font-size', '9'); crossTime.setAttribute('fill', 'var(--tc-muted)');
 	crossTime.setAttribute('display', 'none');
 	// Upload crosshair dot
 	var crossDotUp = document.createElementNS(ns, 'circle');
-	crossDotUp.setAttribute('r', '3'); crossDotUp.setAttribute('fill', 'var(--tm-state-ok)');
+	crossDotUp.setAttribute('r', '3'); crossDotUp.setAttribute('fill', 'var(--tc-ok)');
 	crossDotUp.setAttribute('stroke', '#fff'); crossDotUp.setAttribute('stroke-width', '1.5'); crossDotUp.setAttribute('display', 'none');
 	var crossLabelUp = document.createElementNS(ns, 'text');
-	crossLabelUp.setAttribute('font-size', '9'); crossLabelUp.setAttribute('fill', 'var(--tm-state-ok)');
+	crossLabelUp.setAttribute('font-size', '9'); crossLabelUp.setAttribute('fill', 'var(--tc-ok)');
 	crossLabelUp.setAttribute('font-weight', '500'); crossLabelUp.setAttribute('display', 'none');
 
 	svg.appendChild(crossV); svg.appendChild(crossH);
@@ -597,147 +597,7 @@ function renderFullGraph(history, limitKbit, width, height) {
 	return svg;
 }
 
-function isDarkTheme() {
-	var dm = document.documentElement.getAttribute('data-darkmode');
-	if (dm === 'true') return true;
-	if (dm === 'false') return false;
-	try {
-		var bg = window.getComputedStyle(document.body).backgroundColor;
-		var m = bg.match(/rgb[a]?\((\d+)[,\s]+(\d+)[,\s]+(\d+)/);
-		if (m && (0.299 * +m[1] + 0.587 * +m[2] + 0.114 * +m[3]) < 80) return true;
-	} catch(e) {}
-	return !!(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
-}
-
-function injectStyles() {
-	var el = document.getElementById('tm-style');
-	if (!el) { el = document.createElement('style'); el.id = 'tm-style'; document.head.appendChild(el); }
-	var D = isDarkTheme();
-	el.textContent =
-		':root{' +
-			(D ?
-				'--tm-bg:#1e1e1e;' +
-				'--tm-bg-alt:#262626;' +
-				'--tm-bg-subtle:#242424;' +
-				'--tm-text:#e2e8f0;' +
-				'--tm-text-mute:#a0aec0;' +
-				'--tm-text-faint:#718096;' +
-				'--tm-border:#3a3a3a;' +
-				'--tm-th-bg:#2d3748;' +
-				'--tm-th-fg:#e2e8f0;' +
-				'--tm-proto:#63b3ed;' +
-				'--tm-service:#b794f4;' +
-				'--tm-state-ok:#68d391;' +
-				'--tm-state-wait:#fc8181;' +
-				'--tm-state-close:#f6ad55;' +
-				'--tm-info-bg:#1a365d;' +
-				'--tm-info-border:#2c5282;' +
-				'--tm-info-fg:#bee3f8;' +
-				'--tm-blocked-bg:#3d1818;' +
-				'--tm-blocked-border:#9b2c2c;' +
-				'--tm-blocked-fg:#fc8181;' +
-				'--tm-rate-fg:#f6ad55;' +
-				'--tm-drop-fg:#fc8181;' +
-				'--tm-speed:#63b3ed;' +
-				'--tm-shape-fg:#63b3ed;' +
-				'--tm-hover:#2d3748;' +
-				'--tm-section-action:#252a30;' +
-				'--tm-section-data:#1e1e1e;'
-			:
-				'--tm-bg:#ffffff;' +
-				'--tm-bg-alt:#f7fafc;' +
-				'--tm-bg-subtle:#f7f8fa;' +
-				'--tm-text:#1a202c;' +
-				'--tm-text-mute:#718096;' +
-				'--tm-text-faint:#a0aec0;' +
-				'--tm-border:#e2e8f0;' +
-				'--tm-th-bg:#4a5568;' +
-				'--tm-th-fg:#ffffff;' +
-				'--tm-proto:#2b6cb0;' +
-				'--tm-service:#805ad5;' +
-				'--tm-state-ok:#276749;' +
-				'--tm-state-wait:#c53030;' +
-				'--tm-state-close:#c05621;' +
-				'--tm-info-bg:#ebf8ff;' +
-				'--tm-info-border:#90cdf4;' +
-				'--tm-info-fg:#2c5282;' +
-				'--tm-blocked-bg:#fff5f5;' +
-				'--tm-blocked-border:#fc8181;' +
-				'--tm-blocked-fg:#c53030;' +
-				'--tm-rate-fg:#c05621;' +
-				'--tm-drop-fg:#9b2c2c;' +
-				'--tm-speed:#3182ce;' +
-				'--tm-shape-fg:#2b6cb0;' +
-				'--tm-hover:#ebf8ff;' +
-				'--tm-section-action:#f0f4f8;' +
-				'--tm-section-data:#ffffff;'
-			) +
-		'}' +
-		'@keyframes tm-spin{to{transform:rotate(360deg)}}' +
-		'@keyframes tm-pulse{0%,100%{opacity:.5}50%{opacity:1}}' +
-		'.tm-spinner{display:inline-block;width:14px;height:14px;border:2px solid var(--tm-border);' +
-		'border-top-color:var(--tm-text);border-radius:50%;animation:tm-spin .7s linear infinite;' +
-		'vertical-align:middle;margin-right:6px}' +
-		'.tm-speed-active{color:var(--tm-speed)!important;font-weight:600}' +
-		'.tm-speed-idle{color:var(--tm-text-faint)!important}' +
-		'tr.tm-row:hover td{background:var(--tm-hover)!important;cursor:pointer}' +
-		'.tm-link{color:inherit;text-decoration:none;border-bottom:1px dotted var(--tm-text-faint)}' +
-		'.tm-link:hover{border-bottom-style:solid}' +
-		'.tm-toggle-input{position:absolute;opacity:0;width:0;height:0}' +
-		'.tm-toggle{position:relative;display:inline-block;width:34px;height:18px;background:var(--tm-border);' +
-		'border-radius:9px;cursor:pointer;transition:background .2s}' +
-		'.tm-toggle::after{content:"";position:absolute;top:2px;left:2px;width:14px;height:14px;' +
-		'background:#fff;border-radius:50%;transition:transform .2s;box-shadow:0 1px 2px rgba(0,0,0,.2)}' +
-		'.tm-toggle-input:checked+.tm-toggle{background:var(--tm-proto)}' +
-		'.tm-toggle-input:checked+.tm-toggle::after{transform:translateX(16px)}' +
-		'[data-tip]{position:relative}' +
-		'[data-tip]::after{content:attr(data-tip);position:absolute;bottom:calc(100% + 4px);left:50%;' +
-		'transform:translateX(-50%);padding:4px 8px;border-radius:4px;font-size:11px;font-weight:400;' +
-		'white-space:nowrap;background:var(--tm-th-bg);color:var(--tm-th-fg);' +
-		'pointer-events:none;opacity:0;transition:opacity .1s;z-index:999}' +
-		'[data-tip]:hover::after{opacity:1}' +
-		'.tg-section{border-left:3px solid #0088cc;padding-left:12px;margin-top:4px}' +
-		'.tg-row{display:flex;flex-wrap:wrap;align-items:center;gap:8px}' +
-		'.tg-row+.tg-row{margin-top:8px}' +
-		'.tg-input{font-size:12px;padding:4px 8px;background:var(--tm-bg);color:var(--tm-text);border:1px solid var(--tm-border);border-radius:4px;outline:none;transition:border-color .2s}' +
-		'.tg-input:focus{border-color:#0088cc}' +
-		'.tg-input--token{width:240px}' +
-		'.tg-input--chat{width:120px}' +
-		'.tg-input--template{width:100%;min-height:60px;resize:vertical;font-family:monospace;font-size:11px}' +
-		'.tg-btn{font-size:11px;padding:3px 10px;border:1px solid var(--tm-border);border-radius:4px;background:var(--tm-bg);color:var(--tm-text);cursor:pointer;transition:background .15s}' +
-		'.tg-btn:hover{background:var(--tm-hover)}' +
-		'.tg-btn--primary{background:#0088cc;color:#fff;border-color:#0088cc}' +
-		'.tg-btn--primary:hover{background:#006fa3}' +
-		'.tg-label{font-size:11px;color:var(--tm-text-mute);font-weight:500}' +
-		'.tg-status-dot{display:inline-block;width:8px;height:8px;border-radius:50%;margin-left:6px;vertical-align:middle}' +
-		'.tg-status-dot--on{background:var(--tm-state-ok)}' +
-		'.tg-status-dot--off{background:var(--tm-text-faint)}' +
-		'.tg-segmented{display:inline-flex;border:1px solid var(--tm-border);border-radius:6px;overflow:hidden;font-size:12px}' +
-		'.tg-segmented__item{padding:5px 14px;cursor:pointer;background:var(--tm-bg);color:var(--tm-text-mute);transition:background .15s,color .15s;user-select:none;border-right:1px solid var(--tm-border);border-top:none;border-bottom:none;border-left:none;font-family:inherit;font-size:inherit;line-height:inherit;outline:none}' +
-		'.tg-segmented__item:last-child{border-right:none}' +
-		'.tg-segmented__item--active{background:#0088cc;color:#fff}' +
-		'.tg-divider{font-size:11px;font-weight:600;color:var(--tm-text-mute);margin-top:12px;margin-bottom:6px;padding-bottom:4px;border-bottom:1px solid var(--tm-border)}' +
-		'.tg-bubble{background:var(--tm-bg-alt);border:1px solid var(--tm-border);border-radius:12px 12px 12px 4px;padding:10px 14px;max-width:280px;font-size:12px;line-height:1.5;box-shadow:0 1px 2px rgba(0,0,0,0.06)}' +
-		'.tg-bubble--kbd{text-align:center;border-radius:12px}' +
-		'.tg-kbd-row{display:flex;gap:2px;justify-content:center;margin-top:4px}' +
-		'.tg-kbd-btn{background:#3390ec;color:#fff;border-radius:6px;padding:5px 10px;font-size:11px;flex:1;text-align:center;min-width:0}' +
-		'.tg-commands{background:var(--tm-bg-subtle);border:1px solid var(--tm-border);border-radius:4px;padding:8px 12px;font-family:monospace;font-size:11px;line-height:1.8}' +
-		'.tg-eye{cursor:pointer;font-size:14px;user-select:none;line-height:1}' +
-		'.tg-template-hint{font-size:10px;color:var(--tm-text-faint);margin-top:2px}' +
-		'.tg-save-status{font-size:11px;margin-left:8px;transition:opacity .3s}';
-}
-
-function watchTheme() {
-	var obs = new MutationObserver(injectStyles);
-	obs.observe(document.documentElement, {attributes: true, attributeFilter: ['data-darkmode']});
-	if (window.matchMedia) {
-		try {
-			window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', injectStyles);
-		} catch(e) {
-			window.matchMedia('(prefers-color-scheme: dark)').addListener(injectStyles);
-		}
-	}
-}
+/* styles come from status.css — no runtime injection needed */
 
 
 var PRIVATE_RE = /^(192\.168\.|10\.|172\.(1[6-9]|2[0-9]|3[01])\.)/;
@@ -780,22 +640,22 @@ function buildGroupedTable(groups, sortCol, sortDir) {
 		return sortDir === 'asc' ? av.localeCompare(bv) : bv.localeCompare(av);
 	});
 
-	var thead = E('thead', {}, E('tr', {}, cols.map(function(c) {
+	var titleRow = E('div', { 'class': 'tr cbi-section-table-titles' }, cols.map(function(c) {
 		var arrow = c.key === sortCol ? (sortDir === 'asc' ? ' ▲' : ' ▼') : '';
-		return E('th', { 'class': 'tm-th', 'data-col': c.key, 'data-num': c.num ? '1' : '0' }, c.label + arrow);
-	})));
-
-	var tbody = E('tbody', {}, sorted.map(function(r) {
-		return E('tr', { 'class': 'tm-row' }, [
-			E('td', { 'class': 'tm-td tm-td--medium tm-c-proto' }, escHtml(r.key)),
-			E('td', { 'class': 'tm-td tm-td--right tm-td--bold' }, String(r.count)),
-			E('td', { 'class': 'tm-td tm-td--right tm-c-proto' }, String(r.tcp)),
-			E('td', { 'class': 'tm-td tm-td--right tm-c-close' }, String(r.udp)),
-			E('td', { 'class': 'tm-td tm-td--right tm-td--mono tm-td--medium' }, fmtBytes(r.bytes))
-		]);
+		return E('div', { 'class': 'th', 'data-col': c.key, 'data-num': c.num ? '1' : '0' }, c.label + arrow);
 	}));
 
-	return E('table', { 'class': 'tm-table' }, [thead, tbody]);
+	var rows = sorted.map(function(r) {
+		return E('div', { 'class': 'tr' }, [
+			E('div', { 'class': 'td tc-c-speed tc-fw-bold' }, escHtml(r.key)),
+			E('div', { 'class': 'td tc-right tc-fw-bold' }, String(r.count)),
+			E('div', { 'class': 'td tc-right tc-c-speed' }, String(r.tcp)),
+			E('div', { 'class': 'td tc-right tc-c-warn' }, String(r.udp)),
+			E('div', { 'class': 'td tc-right tc-mono' }, fmtBytes(r.bytes))
+		]);
+	});
+
+	return E('div', { 'class': 'table tc-table' }, [titleRow].concat(rows));
 }
 
 function buildTable(conns, sortCol, sortDir, rdnsMode, hiddenCols) {
@@ -818,44 +678,44 @@ function buildTable(conns, sortCol, sortDir, rdnsMode, hiddenCols) {
 		return sortDir === 'asc' ? av.localeCompare(bv) : bv.localeCompare(av);
 	});
 
-	var thead = E('thead', {}, E('tr', {}, cols.map(function(c) {
+	var titleRow = E('div', { 'class': 'tr cbi-section-table-titles' }, cols.map(function(c) {
 		var arrow = c.key === sortCol ? (sortDir === 'asc' ? ' ▲' : ' ▼') : '';
-		return E('th', { 'class': 'tm-th', 'data-col': c.key, 'data-num': c.num ? '1' : '0' }, c.label + arrow);
-	})));
+		return E('div', { 'class': 'th', 'data-col': c.key, 'data-num': c.num ? '1' : '0' }, c.label + arrow);
+	}));
 
-	var tbody = E('tbody', {}, sorted.map(function(r, i) {
+	var rows = sorted.map(function(r) {
 		var state = escHtml(r.state || '');
-		var scCls = state === 'ESTABLISHED' ? ' tm-c-ok' : state === 'TIME_WAIT' ? ' tm-c-wait' : state === 'CLOSE_WAIT' ? ' tm-c-close' : '';
+		var scCls = state === 'ESTABLISHED' ? ' tc-c-ok' : state === 'TIME_WAIT' ? ' tc-c-err' : state === 'CLOSE_WAIT' ? ' tc-c-warn' : '';
 
 		var dst = r.dst || '';
 		var dstEl = dst
 			? E('a', { 'href': 'https://ipinfo.io/'+dst, 'target': '_blank', 'rel': 'noopener noreferrer',
-			           'class':'tm-link', 'onclick': 'event.stopPropagation()' }, dst)
+			           'class':'tc-link', 'onclick': 'event.stopPropagation()' }, dst)
 			: '';
 
-		var hostCell = E('td', { 'class': 'tm-td tm-td--compact', 'data-dst': dst });
+		var hostCell = E('div', { 'class': 'td', 'data-dst': dst });
 		if (r.host) {
 			hostCell.textContent = r.host;
 		} else if (rdnsMode && !PRIVATE_RE.test(dst)) {
-			hostCell.innerHTML = '<span class="tm-c-faint" style="font-style:italic">' + _('resolving…') + '</span>';
+			hostCell.innerHTML = '<span class="tc-c-faint" style="font-style:italic">' + _('resolving…') + '</span>';
 		} else {
 			hostCell.textContent = '—';
 		}
 
 		var cellMap = {
-			proto: E('td', { 'class': 'tm-td tm-td--compact tm-td--bold tm-c-proto' }, r.proto || ''),
-			dst: E('td', { 'class': 'tm-td tm-td--compact tm-td--mono' }, dstEl),
-			host: hostCell,
-			port: E('td', { 'class': 'tm-td tm-td--compact tm-td--right tm-td--mono' }, String(r.port || '')),
-			service: E('td', { 'class': 'tm-td tm-td--compact tm-c-service' }, escHtml(r.service || (SERVICE_PORTS[r.port]||''))),
-			bytes: E('td', { 'class': 'tm-td tm-td--compact tm-td--right tm-td--mono tm-td--medium' }, fmtBytes(r.bytes)),
-			state: E('td', { 'class': 'tm-td tm-td--compact tm-td--medium' + scCls }, state)
+			proto:   E('div', { 'class': 'td tc-fw-bold tc-c-speed' }, r.proto || ''),
+			dst:     E('div', { 'class': 'td tc-mono' }, dstEl),
+			host:    hostCell,
+			port:    E('div', { 'class': 'td tc-right tc-mono' }, String(r.port || '')),
+			service: E('div', { 'class': 'td tc-c-speed' }, escHtml(r.service || (SERVICE_PORTS[r.port]||''))),
+			bytes:   E('div', { 'class': 'td tc-right tc-mono tc-fw-bold' }, fmtBytes(r.bytes)),
+			state:   E('div', { 'class': 'td tc-fw-bold' + scCls }, state)
 		};
 		var cells = cols.map(function(c) { return cellMap[c.key]; });
-		return E('tr', { 'class': 'tm-row' }, cells);
-	}));
+		return E('div', { 'class': 'tr' }, cells);
+	});
 
-	return E('table', { 'class': 'tm-table' }, [thead, tbody]);
+	return E('div', { 'class': 'table tc-table' }, [titleRow].concat(rows));
 }
 
 function buildSummaryTable(rows, sortCol, sortDir, onSort, onSelect, speedMap, dropMap, shapeMap, speedHistory, hiddenCols) {
@@ -871,8 +731,8 @@ function buildSummaryTable(rows, sortCol, sortDir, onSort, onSelect, speedMap, d
 		{ key:'udp',              label:'UDP',          num:true,  tip: _('UDP bytes transferred'), hide:true },
 		{ key:'blocked',          label: _('Inet'),     num:false, tip: _('Internet access status (paused = traffic blocked)') },
 		{ key:'conn_type',        label: _('Link'),     num:false, tip: _('Connection interface (WiFi band or LAN port)') },
-		{ key:'_throttle_kbit',   label: '⚡',            num:true,  tip: _('Speed limit: shaper (queue) or limiter (drop)') },
-		{ key:'_drop_packets',    label: '🚫',           num:true,  tip: _('Packets dropped by rate limiter'), hide:true },
+		{ key:'_throttle_kbit',   label: _('Limit'),            num:true,  tip: _('Speed limit: shaper (queue) or limiter (drop)') },
+		{ key:'_drop_packets',    label: _('Drop'),           num:true,  tip: _('Packets dropped by rate limiter'), hide:true },
 		{ key:'_backlog',         label: '📦',           num:true,  tip: _('Bytes queued in traffic shaper'), hide:true }
 	];
 
@@ -927,47 +787,47 @@ function buildSummaryTable(rows, sortCol, sortDir, onSort, onSelect, speedMap, d
 	});
 
 	var hasSpeedData = Object.keys(speedMap).length > 0;
-	var thead = E('thead', {}, E('tr', {}, visibleCols.map(function(c) {
+	var titleRow = E('div', { 'class': 'tr cbi-section-table-titles' }, visibleCols.map(function(c) {
 		var arrow = c.key === sortCol ? (sortDir === 'asc' ? ' ▲' : ' ▼') : '';
 		var compact = c.key === '_spark' || c.key === '_throttle_kbit' || c.key === '_drop_packets' || c.key === '_backlog';
-		var thExtra = (c.key === '_spark' ? ';cursor:default;width:68px' : '') + (compact ? ';white-space:nowrap;width:1%' : '');
-		var attrs = { 'class': 'tm-th', 'style': thExtra || undefined, 'data-col': c.key, 'data-num': c.num ? '1' : '0' };
+		var style = (c.key === '_spark' ? 'cursor:default;width:68px;' : '') + (compact ? 'white-space:nowrap;width:1%;' : '');
+		var attrs = { 'class': 'th', 'style': style || undefined, 'data-col': c.key, 'data-num': c.num ? '1' : '0' };
 		if (c.tip) attrs['data-tip'] = c.tip;
 		var label = c.label + arrow;
 		if (c.key === '_speed' && !hasSpeedData) label = c.label + ' ';
-		var th = E('th', attrs);
-		th.innerHTML = label + ((c.key === '_speed' && !hasSpeedData) ? '<span class="tm-spinner"></span>' : '');
+		var th = E('div', attrs);
+		th.innerHTML = label + ((c.key === '_speed' && !hasSpeedData) ? '<span class="tc-spinner"></span>' : '');
 		if (c.key !== '_spark') th.addEventListener('click', function() { onSort(c.key, c.num); });
 		return th;
-	})));
+	}));
 
-	var tbody = E('tbody', {}, sorted.map(function(r, i) {
+	var tableRows = sorted.map(function(r) {
 		var sd = speedMap[r.ip];
 		var cellMap = {};
 
-		cellMap.name = E('td', { 'class': 'tm-td tm-td--bold tm-c-proto' }, escHtml(r.name));
-		cellMap.ip = E('td', { 'class': 'tm-td tm-td--mono' }, escHtml(r.ip));
-		var macEl = r.mac ? E('a', { 'href':'/cgi-bin/luci/admin/network/dhcp','target':'_blank','rel':'noopener','class':'tm-link','title':_('Open DHCP/DNS bindings'),'onclick':'event.stopPropagation()' }, r.mac) : '';
-		cellMap.mac = E('td', { 'class': 'tm-td tm-td--mono tm-td--sm tm-c-mute' }, macEl || '');
+		cellMap.name = E('div', { 'class': 'td tc-fw-bold tc-c-speed' }, escHtml(r.name));
+		cellMap.ip   = E('div', { 'class': 'td tc-mono' }, escHtml(r.ip));
+		var macEl = r.mac ? E('a', { 'href':'/cgi-bin/luci/admin/network/dhcp','target':'_blank','rel':'noopener','class':'tc-link','title':_('Open DHCP/DNS bindings'),'onclick':'event.stopPropagation()' }, r.mac) : '';
+		cellMap.mac  = E('div', { 'class': 'td tc-mono tc-sm tc-c-muted' }, macEl || '');
 
-		cellMap._speed = E('td', { 'class': 'tm-td tm-td--right tm-td--mono', 'data-speed-ip': r.ip, 'title': sd ? (_('Avg')+': '+fmtSpeed(sd.avg)+' / '+_('Max')+': '+fmtSpeed(sd.max)) : _('Calculating…') });
-		if (sd && sd.current > 1024) { cellMap._speed.className = 'tm-speed-active'; cellMap._speed.textContent = fmtSpeed(sd.current); }
-		else { cellMap._speed.className = 'tm-speed-idle'; cellMap._speed.textContent = sd ? fmtSpeed(sd.current) : '—'; }
+		cellMap._speed = E('div', { 'class': 'td tc-right tc-mono', 'data-speed-ip': r.ip, 'title': sd ? (_('Avg')+': '+fmtSpeed(sd.avg)+' / '+_('Max')+': '+fmtSpeed(sd.max)) : _('Calculating…') });
+		if (sd && sd.current > 1024) { cellMap._speed.className = 'td tc-right tc-mono tc-speed-active'; cellMap._speed.textContent = fmtSpeed(sd.current); }
+		else { cellMap._speed.className = 'td tc-right tc-mono tc-speed-idle'; cellMap._speed.textContent = sd ? fmtSpeed(sd.current) : '—'; }
 
 		var sparkTip = r._throttle_kbit > 0 ? (_('Limit') + ': ' + fmtRate(r._throttle_kbit)) : '';
-		cellMap._spark = E('td', { 'class': 'tm-td tm-td--center', 'style': 'padding:2px 4px', 'data-spark-ip': r.ip, 'data-tip': sparkTip || undefined });
+		cellMap._spark = E('div', { 'class': 'td tc-center', 'style': 'padding:2px 4px', 'data-spark-ip': r.ip, 'data-tip': sparkTip || undefined });
 		var sparkSvg = renderSparkline(speedHistory[r.ip], globalSpeedMax, 60, 20, r._throttle_kbit);
 		if (sparkSvg) cellMap._spark.appendChild(sparkSvg);
 
-		cellMap.conns = E('td', { 'class': 'tm-td tm-td--right tm-td--bold' }, String(r.conns||0));
-		cellMap.total = E('td', { 'class': 'tm-td tm-td--right tm-td--mono tm-td--sm' }, fmtBytes(r.total||0));
-		cellMap.tcp = E('td', { 'class': 'tm-td tm-td--right tm-td--mono tm-td--sm tm-c-proto' }, fmtBytes(r.tcp||0));
-		cellMap.udp = E('td', { 'class': 'tm-td tm-td--right tm-td--mono tm-td--sm tm-c-close' }, fmtBytes(r.udp||0));
+		cellMap.conns = E('div', { 'class': 'td tc-right tc-fw-bold' }, String(r.conns||0));
+		cellMap.total = E('div', { 'class': 'td tc-right tc-mono tc-sm' }, fmtBytes(r.total||0));
+		cellMap.tcp   = E('div', { 'class': 'td tc-right tc-mono tc-sm tc-c-speed' }, fmtBytes(r.tcp||0));
+		cellMap.udp   = E('div', { 'class': 'td tc-right tc-mono tc-sm tc-c-warn' }, fmtBytes(r.udp||0));
 
 		var inetBadge = r.blocked
-			? E('span', { 'class': 'tm-c-rate tm-fw-600' }, '⏸️ ' + _('paused'))
-			: E('span', { 'class': 'tm-c-proto' }, '▶️ ' + _('ok'));
-		cellMap.blocked = E('td', { 'class': 'tm-td tm-td--center' }, inetBadge);
+			? E('span', { 'class': 'tc-c-warn tc-fw-bold' }, '⏸ ' + _('blocked'))
+			: E('span', { 'class': 'tc-c-faint' }, '—');
+		cellMap.blocked = E('div', { 'class': 'td tc-center' }, inetBadge);
 
 		var linkBadge;
 		var ct = r.conn_type || 'ethernet';
@@ -984,44 +844,45 @@ function buildSummaryTable(rows, sortCol, sortDir, onSort, onSelect, speedMap, d
 					tip = _('Last seen') + ': ' + lastType + ', ' + agoStr + ' ' + _('ago');
 				}
 			}
-			linkBadge = E('span', { 'class': 'tm-c-faint', 'style': 'cursor:help', 'title': tip }, '❓');
+			linkBadge = E('span', { 'class': 'tc-c-faint', 'style': 'cursor:help', 'title': tip }, '?');
 		} else if (isWifi) {
 			var wLabel = ct === 'wifi' ? 'WiFi' : ct;
 			linkBadge = r.wifi_blocked
-				? E('span', { 'class': 'tm-c-rate tm-fw-600', 'style': 'text-decoration:line-through' }, '📶 ' + wLabel)
-				: E('span', { 'class': 'tm-c-proto' }, '📶 ' + wLabel);
+				? E('span', { 'class': 'tc-c-warn tc-fw-bold', 'style': 'text-decoration:line-through' }, wLabel)
+				: E('span', { 'class': 'tc-c-speed' }, wLabel);
 		} else {
 			var ethLabel = (ct === 'ethernet') ? 'eth' : ct;
-			linkBadge = E('span', { 'class': 'tm-c-mute' }, [mkEthIcon(14), document.createTextNode(ethLabel)]);
+			linkBadge = E('span', { 'class': 'tc-c-muted' }, [mkEthIcon(14), document.createTextNode(ethLabel)]);
 		}
-		cellMap.conn_type = E('td', { 'class': 'tm-td tm-td--center' }, linkBadge);
+		cellMap.conn_type = E('div', { 'class': 'td tc-center' }, linkBadge);
 
 		var throttleBadge;
-		if (r._throttle_mode === 'shaper') { throttleBadge = E('span', { 'class': 'tm-c-shape tm-fw-600', 'title': _('Shaper (tc/HTB queue)') }, '🌊 ' + fmtRate(r._throttle_kbit)); }
-		else if (r._throttle_mode === 'limiter') { throttleBadge = E('span', { 'class': 'tm-c-rate tm-fw-600', 'title': _('Limiter (nft drop)') }, '⚡ ' + fmtRate(r._throttle_kbit)); }
-		else { throttleBadge = E('span', { 'class': 'tm-c-faint' }, '—'); }
-		cellMap._throttle_kbit = E('td', { 'class': 'tm-td tm-td--center' }, throttleBadge);
+		if (r._throttle_mode === 'shaper') { throttleBadge = E('span', { 'class': 'tc-c-speed tc-fw-bold', 'title': _('Shaper (tc/HTB queue)') }, '≈ ' + fmtRate(r._throttle_kbit)); }
+		else if (r._throttle_mode === 'limiter') { throttleBadge = E('span', { 'class': 'tc-c-warn tc-fw-bold', 'title': _('Limiter (nft drop)') }, '⚡ ' + fmtRate(r._throttle_kbit)); }
+		else { throttleBadge = E('span', { 'class': 'tc-c-faint' }, '—'); }
+		cellMap._throttle_kbit = E('div', { 'class': 'td tc-center' }, throttleBadge);
 
 		var dp = r._drop_packets || 0;
-		var dropBadge = dp > 0 ? E('span', { 'class': 'tm-c-drop tm-fw-600', 'title': fmtBytes(r._drop_bytes||0)+' '+_('dropped') }, '🚫 ' + dp) : E('span', { 'class': 'tm-c-faint' }, '—');
-		cellMap._drop_packets = E('td', { 'class': 'tm-td tm-td--center', 'data-drop-ip': r.ip }, dropBadge);
+		var dropBadge = dp > 0 ? E('span', { 'class': 'tc-c-err tc-fw-bold', 'title': fmtBytes(r._drop_bytes||0)+' '+_('dropped') }, String(dp)) : E('span', { 'class': 'tc-c-faint' }, '—');
+		cellMap._drop_packets = E('div', { 'class': 'td tc-center', 'data-drop-ip': r.ip }, dropBadge);
 
 		var bl = r._backlog || 0;
-		var backlogBadge = bl > 0 ? E('span', { 'class': 'tm-c-shape tm-fw-600', 'title': _('Bytes queued in tc') }, fmtBytes(bl)) : E('span', { 'class': 'tm-c-faint' }, '—');
-		cellMap._backlog = E('td', { 'class': 'tm-td tm-td--center', 'data-backlog-ip': r.ip }, backlogBadge);
+		var backlogBadge = bl > 0 ? E('span', { 'class': 'tc-c-speed tc-fw-bold', 'title': _('Bytes queued in tc') }, fmtBytes(bl)) : E('span', { 'class': 'tc-c-faint' }, '—');
+		cellMap._backlog = E('div', { 'class': 'td tc-center', 'data-backlog-ip': r.ip }, backlogBadge);
 
 		var cells = visibleCols.map(function(c) { return cellMap[c.key]; });
-		var row = E('tr', { 'class': 'tm-row', 'title': _('Click to inspect') + ' ' + r.name }, cells);
+		var row = E('div', { 'class': 'tr', 'title': _('Click to inspect') + ' ' + r.name }, cells);
 		row.addEventListener('click', function() { addRecentDevice(r.ip, r.name); onSelect(r.ip, r.name); });
 		return row;
-	}));
+	});
 
-	return E('table', { 'class': 'tm-table' }, [thead, tbody]);
+	return E('div', { 'class': 'table tc-table' }, [titleRow].concat(tableRows));
 }
 
 function setStatus(el, type, msg) {
-	el.className = 'tm-status tm-status--' + (type || 'ok');
-	el.innerHTML = type === 'loading' ? '<span class="tm-spinner"></span>'+escHtml(msg) : escHtml(msg);
+	var cls = {loading: '', ok: 'success', error: 'error', action: 'warning'};
+	el.className = 'alert-message ' + (cls[type] || '');
+	el.innerHTML = type === 'loading' ? '<span class="tc-spinner"></span>'+escHtml(msg) : escHtml(msg);
 }
 
 function updateUrlParams(opts) {
@@ -1062,7 +923,6 @@ function buildExtendedStatsPanel(ip, shapeMap, dropMap, speedMap) {
 	var dm = dropMap[ip];
 	var spd = speedMap[ip];
 
-	var td = 'padding:5px 12px;border-bottom:1px solid var(--tm-border);font-size:13px';
 	var tooltips = {
 		'Drops': _('packets dropped by queue overflow'),
 		'Overlimits': _('rate exceeded events'),
@@ -1079,16 +939,16 @@ function buildExtendedStatsPanel(ip, shapeMap, dropMap, speedMap) {
 
 	function addRow(label, value, color) {
 		var tip = tooltips[label] || '';
-		rows.push(E('tr', { 'class': 'tm-row' }, [
-			E('td', { 'style': td + ';color:var(--tm-text-mute)', 'title': tip }, label),
-			E('td', { 'style': td + ';text-align:right;font-family:monospace;font-weight:600' + (color ? ';color:' + color : '') }, value)
+		rows.push(E('div', { 'class': 'tr' }, [
+			E('div', { 'class': 'td tc-c-muted', 'title': tip }, label),
+			E('div', { 'class': 'td tc-right tc-mono tc-fw-bold', 'style': color ? 'color:' + color : '' }, value)
 		]));
 	}
 
 	if (sm && sm.rate_kbit > 0) {
-		if (sm.drops != null) addRow(_('Drops'), String(sm.drops), sm.drops > 0 ? 'var(--tm-drop-fg)' : null);
-		if (sm.overlimits != null) addRow(_('Overlimits'), String(sm.overlimits), sm.overlimits > 0 ? 'var(--tm-rate-fg)' : null);
-		if (sm.ecn_mark != null) addRow(_('ECN marks'), String(sm.ecn_mark), sm.ecn_mark > 0 ? 'var(--tm-rate-fg)' : null);
+		if (sm.drops != null) addRow(_('Drops'), String(sm.drops), sm.drops > 0 ? 'var(--tc-err)' : null);
+		if (sm.overlimits != null) addRow(_('Overlimits'), String(sm.overlimits), sm.overlimits > 0 ? 'var(--tc-warn)' : null);
+		if (sm.ecn_mark != null) addRow(_('ECN marks'), String(sm.ecn_mark), sm.ecn_mark > 0 ? 'var(--tc-warn)' : null);
 		if (sm.new_flows != null || sm.old_flows != null) {
 			addRow(_('Flows'), (sm.new_flows || 0) + ' ' + _('new') + ' / ' + (sm.old_flows || 0) + ' ' + _('old'), null);
 		}
@@ -1100,37 +960,33 @@ function buildExtendedStatsPanel(ip, shapeMap, dropMap, speedMap) {
 			var currentBps = spd.current || 0;
 			var rateBytes = (sm.rate_kbit * 1000) / 8;
 			var util = rateBytes > 0 ? ((currentBps / rateBytes) * 100) : 0;
-			var utilColor = util > 95 ? 'var(--tm-drop-fg)' : util > 70 ? 'var(--tm-rate-fg)' : 'var(--tm-state-ok)';
+			var utilColor = util > 95 ? 'var(--tc-err)' : util > 70 ? 'var(--tc-warn)' : 'var(--tc-ok)';
 			addRow(_('Utilization'), util.toFixed(1) + '%', utilColor);
 		}
 	} else if (dm && dm.rate_kbit > 0) {
-		addRow(_('Packets dropped'), String(dm.packets || 0), (dm.packets || 0) > 0 ? 'var(--tm-drop-fg)' : null);
-		addRow(_('Bytes dropped'), fmtBytes(dm.bytes || 0), (dm.bytes || 0) > 0 ? 'var(--tm-drop-fg)' : null);
+		addRow(_('Packets dropped'), String(dm.packets || 0), (dm.packets || 0) > 0 ? 'var(--tc-err)' : null);
+		addRow(_('Bytes dropped'), fmtBytes(dm.bytes || 0), (dm.bytes || 0) > 0 ? 'var(--tc-err)' : null);
 		var dropBytes = dm.bytes || 0;
 		var passBytes = dm.pass_bytes || 0;
 		var totalBytes = dropBytes + passBytes;
 		var dropRatio = totalBytes > 0 ? ((dropBytes / totalBytes) * 100) : 0;
-		var drColor = dropRatio > 10 ? 'var(--tm-drop-fg)' : dropRatio > 2 ? 'var(--tm-rate-fg)' : null;
+		var drColor = dropRatio > 10 ? 'var(--tc-err)' : dropRatio > 2 ? 'var(--tc-warn)' : null;
 		addRow(_('Drop ratio'), dropRatio.toFixed(1) + '%', drColor);
 	}
 
 	if (rows.length === 0) {
-		return E('div', { 'class': 'tm-ext-panel', 'style': 'color:var(--tm-text-mute)' }, _('No extended stats available for this device.'));
+		return E('div', { 'class': 'tc-ext-panel', 'style': 'color:var(--tc-muted)' }, _('No extended stats available for this device.'));
 	}
 
-	var tbl = E('table', { 'class': 'tm-table' }, [
-		E('tbody', {}, rows)
-	]);
-
-	return E('div', { 'class': 'tm-ext-panel' }, [
-		E('div', { 'class': 'tm-ext-panel__title' }, _('Extended Statistics')),
-		tbl
+	return E('div', { 'class': 'tc-ext-panel' }, [
+		E('div', { 'class': 'tc-ext-panel__title' }, _('Extended Statistics')),
+		E('div', { 'class': 'table tc-table' }, rows)
 	]);
 }
 
 function buildExtendedStatsLegend(shapeMap, dropMap) {
-	var labelStyle = 'color:var(--tm-text-mute);font-size:12px';
-	var valueStyle = 'font-family:monospace;font-weight:600;color:var(--tm-text);font-size:13px';
+	var labelStyle = 'color:var(--tc-muted);font-size:12px';
+	var valueStyle = 'font-family:monospace;font-weight:600;color:currentColor;font-size:13px';
 	var totalDrops = 0, totalOverlimits = 0, totalEcn = 0, totalMemory = 0;
 	var totalDropPkts = 0, totalDropBytes = 0;
 	var shapedCount = 0, limitedCount = 0;
@@ -1157,30 +1013,30 @@ function buildExtendedStatsLegend(shapeMap, dropMap) {
 	var rows = [];
 	function addRow(label, value, color) {
 		var vs = color ? valueStyle + ';color:' + color : valueStyle;
-		rows.push(E('div', { 'class': 'tm-ext-row' }, [
+		rows.push(E('div', { 'class': 'tc-ext-row' }, [
 			E('span', { 'style': labelStyle }, label),
 			E('span', { 'style': vs }, value)
 		]));
 	}
 
 	if (shapedCount > 0) {
-		addRow(_('Shaped devices'), String(shapedCount), 'var(--tm-shape-fg)');
-		addRow(_('Total drops'), String(totalDrops), totalDrops > 0 ? 'var(--tm-drop-fg)' : null);
-		addRow(_('Overlimits'), String(totalOverlimits), totalOverlimits > 0 ? 'var(--tm-rate-fg)' : null);
+		addRow(_('Shaped devices'), String(shapedCount), 'var(--tc-speed)');
+		addRow(_('Total drops'), String(totalDrops), totalDrops > 0 ? 'var(--tc-err)' : null);
+		addRow(_('Overlimits'), String(totalOverlimits), totalOverlimits > 0 ? 'var(--tc-warn)' : null);
 		addRow(_('ECN marks'), String(totalEcn));
 		addRow(_('Total queue memory'), fmtBytes(totalMemory));
 	}
 	if (limitedCount > 0) {
-		addRow(_('Limited devices'), String(limitedCount), 'var(--tm-rate-fg)');
-		addRow(_('Total dropped'), totalDropPkts + ' ' + _('pkts') + ' / ' + fmtBytes(totalDropBytes), totalDropPkts > 0 ? 'var(--tm-drop-fg)' : null);
+		addRow(_('Limited devices'), String(limitedCount), 'var(--tc-warn)');
+		addRow(_('Total dropped'), totalDropPkts + ' ' + _('pkts') + ' / ' + fmtBytes(totalDropBytes), totalDropPkts > 0 ? 'var(--tc-err)' : null);
 	}
 	if (rows.length === 0) {
-		rows.push(E('div', { 'style': 'padding:4px 0;color:var(--tm-text-mute)' }, _('No extended stats available.')));
+		rows.push(E('div', { 'style': 'padding:4px 0;color:var(--tc-muted)' }, _('No extended stats available.')));
 	}
 
-	return E('div', { 'class': 'tm-ext-panel tm-ext-panel--sticky' }, [
-		E('div', { 'class': 'tm-ext-panel__title' }, _('Extended Statistics') + ' (' + _('all devices') + ')'),
-		E('div', { 'class': 'tm-ext-col-flex' }, rows)
+	return E('div', { 'class': 'tc-ext-panel tc-ext-panel--sticky' }, [
+		E('div', { 'class': 'tc-ext-panel__title' }, _('Extended Statistics') + ' (' + _('all devices') + ')'),
+		E('div', { 'class': 'tc-ext-col-flex' }, rows)
 	]);
 }
 
@@ -1207,198 +1063,20 @@ function deviceIcon(type, size) {
 	return E('span', {'style':'font-size:'+(size||18)+'px;line-height:1'}, icons[type] || icons.device);
 }
 
-function buildCardGrid(devices, onSelect, speedMap, shapeMap, dropMap) {
-	var selectedValue = '__all__';
-	var wrapper = E('div', {'class':'tm-card-grid'});
-
-	function render(devs) {
-		while (wrapper.firstChild) wrapper.removeChild(wrapper.firstChild);
-
-		var allCard = E('div', {
-			'class': 'tm-card tm-card--all',
-			'data-value': '__all__'
-		}, [E('span', {'style':'font-size:20px'}, '📊'), E('span', {}, _('All devices'))]);
-		allCard.addEventListener('click', function() { selectItem('__all__'); });
-		wrapper.appendChild(allCard);
-
-		devs.forEach(function(d) {
-			var type = guessDeviceType(d);
-			var spd = speedMap && speedMap[d.ip];
-			var sm = shapeMap && shapeMap[d.ip];
-			var dm = dropMap && dropMap[d.ip];
-			var isBlocked = d.blocked;
-			var hasLimit = (sm && sm.rate_kbit > 0) || (dm && dm.rate_kbit > 0);
-
-			var statusDot = isBlocked ? '🔴' : (hasLimit ? '🟠' : (spd && spd.current > 1024 ? '🟢' : '⚪'));
-			var speedLabel = spd && spd.current > 0 ? fmtSpeed(spd.current) : '';
-			var isSelected = selectedValue === d.ip;
-			var card = E('div', {
-				'class': 'tm-card',
-				'style': isSelected ? 'border-color:var(--tm-proto);background:var(--tm-info-bg)' : '',
-				'data-value': d.ip,
-				'title': d.name + ' (' + d.ip + ')'
-			}, [
-				E('div', {'class':'tm-device-icon-wrap'}, [
-					deviceIcon(type, 22),
-					E('span', {'class':'tm-device-icon-badge'}, statusDot)
-				]),
-				E('div', {'class':'tm-card__name'}, d.name || d.ip),
-				E('div', {'class':'tm-card__ip'}, d.ip),
-				speedLabel ? E('div', {'class':'tm-card__speed'}, speedLabel) : E('span')
-			]);
-			card.addEventListener('click', function() { selectItem(d.ip); });
-			card.addEventListener('mouseenter', function() { if (selectedValue !== d.ip) this.style.borderColor = 'var(--tm-text-mute)'; });
-			card.addEventListener('mouseleave', function() { if (selectedValue !== d.ip) this.style.borderColor = 'var(--tm-border)'; });
-			wrapper.appendChild(card);
-		});
-	}
-
-	function selectItem(value) {
-		selectedValue = value;
-		render(devices);
-		onSelect(value);
-	}
-
-	render(devices);
-	return {
-		el: wrapper,
-		getValue: function() { return selectedValue; },
-		setValue: function(val) { selectedValue = val; render(devices); },
-		updateDevices: function(newDevices) { devices = newDevices; render(devices); },
-		refresh: function(sm, dm, spdm) { speedMap = spdm; shapeMap = sm; dropMap = dm; render(devices); }
-	};
-}
-
-function buildAvatarStrip(devices, onSelect, speedMap) {
-	var selectedValue = '__all__';
-	var wrapper = E('div', {'class':'tm-avatar-strip'});
-
-	function render(devs) {
-		while (wrapper.firstChild) wrapper.removeChild(wrapper.firstChild);
-
-		var allPill = E('div', {
-			'class':'tm-avatar-pill',
-			'data-value':'__all__'
-		}, [
-			E('div', {'style':'width:42px;height:42px;border-radius:50%;display:flex;align-items:center;justify-content:center;' +
-				'border:2px solid '+(selectedValue==='__all__'?'var(--tm-proto)':'var(--tm-border)')+';' +
-				'background:'+(selectedValue==='__all__'?'var(--tm-info-bg)':'var(--tm-bg)')+';font-size:18px;transition:all .15s'}, '📊'),
-			E('div', {'style':'font-size:9px;color:'+(selectedValue==='__all__'?'var(--tm-proto)':'var(--tm-text-mute)')+';font-weight:'+(selectedValue==='__all__'?'700':'400')+';text-align:center;max-width:56px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap'}, _('All'))
-		]);
-		allPill.addEventListener('click', function() { selectItem('__all__'); });
-		wrapper.appendChild(allPill);
-
-		devs.forEach(function(d) {
-			var type = guessDeviceType(d);
-			var isActive = selectedValue === d.ip;
-			var spd = speedMap && speedMap[d.ip];
-			var hasSpeed = spd && spd.current > 1024;
-			var ringColor = isActive ? 'var(--tm-proto)' : (hasSpeed ? 'var(--tm-speed)' : 'var(--tm-border)');
-			var bg = isActive ? 'var(--tm-info-bg)' : 'var(--tm-bg)';
-
-			var pill = E('div', {
-				'class':'tm-avatar-pill',
-				'data-value': d.ip,
-				'title': d.name + ' — ' + d.ip
-			}, [
-				E('div', {'style':'width:42px;height:42px;border-radius:50%;display:flex;align-items:center;justify-content:center;' +
-					'border:2px solid '+ringColor+';background:'+bg+';font-size:18px;transition:all .15s'}, deviceIcon(type, 20)),
-				E('div', {'style':'font-size:9px;color:'+(isActive?'var(--tm-proto)':'var(--tm-text-mute)')+';font-weight:'+(isActive?'700':'400')+';text-align:center;max-width:56px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap'}, d.name || d.ip)
-			]);
-			pill.addEventListener('click', function() { selectItem(d.ip); });
-			wrapper.appendChild(pill);
-		});
-	}
-
-	function selectItem(value) {
-		selectedValue = value;
-		render(devices);
-		onSelect(value);
-	}
-
-	render(devices);
-	return {
-		el: wrapper,
-		getValue: function() { return selectedValue; },
-		setValue: function(val) { selectedValue = val; render(devices); },
-		updateDevices: function(newDevices) { devices = newDevices; render(devices); },
-		refresh: function(spdm) { speedMap = spdm; render(devices); }
-	};
-}
-
-function buildChipCloud(devices, onSelect, speedMap, shapeMap, dropMap) {
-	var selectedValue = '__all__';
-	var wrapper = E('div', {'class':'tm-chip-cloud'});
-
-	var chipNorm    = 'tm-cloud-chip';
-	var chipActive  = 'tm-cloud-chip tm-cloud-chip--active';
-	var chipBlocked = 'tm-cloud-chip tm-cloud-chip--blocked';
-	var chipLimited = 'tm-cloud-chip tm-cloud-chip--limited';
-
-	function render(devs) {
-		while (wrapper.firstChild) wrapper.removeChild(wrapper.firstChild);
-
-		var allChip = E('span', {'class': selectedValue === '__all__' ? chipActive : chipNorm}, [
-			E('span', {'style':'font-size:13px'}, '📊'),
-			E('span', {}, _('All'))
-		]);
-		allChip.addEventListener('click', function() { selectItem('__all__'); });
-		wrapper.appendChild(allChip);
-
-		devs.forEach(function(d) {
-			var type = guessDeviceType(d);
-			var sm = shapeMap && shapeMap[d.ip];
-			var dm = dropMap && dropMap[d.ip];
-			var isBlocked = d.blocked;
-			var hasLimit = (sm && sm.rate_kbit > 0) || (dm && dm.rate_kbit > 0);
-			var spd = speedMap && speedMap[d.ip];
-			var speedTxt = spd && spd.current > 1024 ? ' ' + fmtSpeed(spd.current) : '';
-
-			var chipClass;
-			if (selectedValue === d.ip) chipClass = chipActive;
-			else if (isBlocked) chipClass = chipBlocked;
-			else if (hasLimit) chipClass = chipLimited;
-			else chipClass = chipNorm;
-
-			var chip = E('span', {'class': chipClass, 'title': d.ip + (d.mac ? ' ('+d.mac+')' : '')}, [
-				deviceIcon(type, 13),
-				E('span', {}, d.name || d.ip),
-				speedTxt ? E('span', {'class':'tm-cloud-chip__speed'}, speedTxt) : E('span')
-			]);
-			chip.addEventListener('click', function() { selectItem(d.ip); });
-			wrapper.appendChild(chip);
-		});
-	}
-
-	function selectItem(value) {
-		selectedValue = value;
-		render(devices);
-		onSelect(value);
-	}
-
-	render(devices);
-	return {
-		el: wrapper,
-		getValue: function() { return selectedValue; },
-		setValue: function(val) { selectedValue = val; render(devices); },
-		updateDevices: function(newDevices) { devices = newDevices; render(devices); },
-		refresh: function(sm, dm, spdm) { speedMap = spdm; shapeMap = sm; dropMap = dm; render(devices); }
-	};
-}
 
 function buildSearchSelect(devices, placeholder, onSelect) {
 	var selectedValue = '__all__';
 	var recentIps = [];
 	var MAX_RECENT = 5;
-	var wrapper = E('div', { 'class': 'tm-search-wrapper' });
+	var wrapper = E('div', { 'class': 'tc-search-wrapper' });
 	var input = E('input', {
 		'type': 'text',
 		'placeholder': placeholder,
 		'autocomplete': 'off',
-		'class': 'tm-search-input'
+		'class': 'tc-search-input'
 	});
-	var clearBtn = E('span', { 'class': 'tm-search-clear tm-hidden' }, '×');
-	var dropdown = E('div', { 'class': 'tm-search-dropdown tm-hidden' });
+	var clearBtn = E('span', { 'class': 'tc-search-clear tc-hidden' }, '×');
+	var dropdown = E('div', { 'class': 'tc-search-dropdown tc-hidden' });
 	wrapper.appendChild(input);
 	wrapper.appendChild(clearBtn);
 	wrapper.appendChild(dropdown);
@@ -1424,18 +1102,18 @@ function buildSearchSelect(devices, placeholder, onSelect) {
 	}
 
 	function mkItem(it, idx, q) {
-		var item = E('div', { 'class': 'tm-dropdown-item', 'data-value': it.value });
+		var item = E('div', { 'class': 'tc-dropdown-item', 'data-value': it.value });
 		if (q && it.value !== '__all__') {
 			item.innerHTML = highlightMatch(it.label, q);
 		} else {
 			item.textContent = it.label;
 		}
 		if (it.section) {
-			item.className = 'tm-dropdown-item--section';
+			item.className = 'tc-dropdown-item--section';
 			return item;
 		}
 		if (it.value === '__all__') {
-			item.className = 'tm-dropdown-item tm-dropdown-item--all';
+			item.className = 'tc-dropdown-item tc-dropdown-item--all';
 		}
 		item.addEventListener('mousedown', function(ev) {
 			ev.preventDefault();
@@ -1483,7 +1161,7 @@ function buildSearchSelect(devices, placeholder, onSelect) {
 		var actionIdx = 0;
 		Array.prototype.forEach.call(dd.children, function(el) {
 			if (el.getAttribute('data-value') && el.getAttribute('data-value').indexOf('_hdr_') === 0) return;
-			el.style.background = actionIdx === highlightIdx ? 'var(--tm-hover)' : '';
+			el.style.background = actionIdx === highlightIdx ? 'var(--tc-hover)' : '';
 			actionIdx++;
 		});
 	}
@@ -1492,32 +1170,32 @@ function buildSearchSelect(devices, placeholder, onSelect) {
 		selectedValue = value;
 		if (value === '__all__') {
 			input.value = '';
-			clearBtn.classList.add('tm-hidden');
+			clearBtn.classList.add('tc-hidden');
 		} else {
 			addToRecent(value);
 			input.value = label.replace(/\s+\(.*\)$/, '');
-			clearBtn.classList.remove('tm-hidden');
+			clearBtn.classList.remove('tc-hidden');
 		}
-		dropdown.classList.add('tm-hidden');
+		dropdown.classList.add('tc-hidden');
 		if (!silent) onSelect(value);
 	}
 
 	input.addEventListener('focus', function() {
 		this.style.cursor = 'text';
 		renderItems(input.value);
-		dropdown.classList.remove('tm-hidden');
+		dropdown.classList.remove('tc-hidden');
 	});
 	input.addEventListener('blur', function() {
 		this.style.cursor = 'pointer';
-		setTimeout(function() { dropdown.classList.add('tm-hidden'); }, 150);
+		setTimeout(function() { dropdown.classList.add('tc-hidden'); }, 150);
 	});
 	input.addEventListener('click', function() {
 		renderItems(input.value);
-		dropdown.classList.remove('tm-hidden');
+		dropdown.classList.remove('tc-hidden');
 	});
 	input.addEventListener('input', function() {
 		renderItems(input.value);
-		dropdown.classList.remove('tm-hidden');
+		dropdown.classList.remove('tc-hidden');
 	});
 	input.addEventListener('keydown', function(ev) {
 		var actionItems = [];
@@ -1540,7 +1218,7 @@ function buildSearchSelect(devices, placeholder, onSelect) {
 				selectItem(el.getAttribute('data-value'), el.textContent);
 			}
 		} else if (ev.key === 'Escape') {
-			dropdown.classList.add('tm-hidden');
+			dropdown.classList.add('tc-hidden');
 			input.blur();
 		}
 	});
@@ -1586,9 +1264,6 @@ return view.extend({
 		var opts = loadOpts();
 		opts = applyUrlParams(opts);
 		saveOpts(opts);
-		injectStyles();
-		watchTheme();
-
 		var devices = [];
 		(leasesRaw || '').split('\n').forEach(function(line) {
 			var p = line.trim().split(/\s+/);
@@ -1620,16 +1295,16 @@ return view.extend({
 		// Recent devices — functions defined at top level
 
 		// Quick-access bar: [All devices] + recent device chips
-		var quickBar = E('div', {'class':'tm-quick-bar'});
+		var quickBar = E('div', {'class':'tc-quick-bar'});
 
-		var allBtn = E('span', {'class':'tm-quick-bar__all'}, ['📊 ', _('All devices')]);
+		var allBtn = E('span', {'class':'cbi-button cbi-button-action'}, ['📊 ', _('All devices')]);
 		allBtn.addEventListener('click', function() {
 			searchSelect.setValue('__all__', '');
 			onDeviceSelect('__all__');
 		});
 		quickBar.appendChild(allBtn);
 
-		var recentContainer = E('span', {'class':'tm-recent-container'});
+		var recentContainer = E('span', {'class':'tc-recent-container'});
 		quickBar.appendChild(recentContainer);
 
 
@@ -1639,9 +1314,9 @@ return view.extend({
 			var currentIp = searchSelect.getValue();
 
 			// Update All button style
-			// tm-quick-bar__all has the active (filled) look by default;
+			// cbi-button cbi-button-action has the active (filled) look by default;
 			// when a device is selected we switch to outline-only variant
-			allBtn.className = currentIp === '__all__' ? 'tm-quick-bar__all' : 'tm-quick-bar__all tm-quick-bar__all--outline';
+			allBtn.className = currentIp === '__all__' ? 'cbi-button cbi-button-action' : 'cbi-button cbi-button-action cbi-button-action';
 
 			recent.forEach(function(entry) {
 				var ip = entry.ip || entry;
@@ -1650,7 +1325,7 @@ return view.extend({
 				var label = (dev && dev.name) || storedName || ip;
 				var isActive = ip === currentIp;
 				var chip = E('span', {
-					'class': isActive ? 'tm-recent-chip tm-recent-chip--active' : 'tm-recent-chip',
+					'class': isActive ? 'tc-recent-chip tc-recent-chip--active' : 'tc-recent-chip',
 					'title': ip + (dev && dev.mac ? ' (' + dev.mac + ')' : '')
 				}, [
 					deviceIcon(guessDeviceType(dev || {name:label}), 12),
@@ -1661,7 +1336,7 @@ return view.extend({
 					searchSelect.setValue(ip, lbl);
 					onDeviceSelect(ip);
 				});
-				var removeBtn = E('span', {'class':'tm-recent-remove'}, '×');
+				var removeBtn = E('span', {'class':'tc-recent-remove'}, '×');
 				removeBtn.addEventListener('click', function(ev) {
 					ev.stopPropagation();
 					var r = getRecentDevices().filter(function(x) { return (x.ip || x) !== ip; });
@@ -1677,23 +1352,23 @@ return view.extend({
 		renderRecentChips();
 
 		function mkToggle(id, label, checked, onChange) {
-			var cb = E('input', { 'type': 'checkbox', 'id': id, 'class': 'tm-toggle-input' });
+			var cb = E('input', { 'type': 'checkbox', 'id': id, 'class': 'tc-toggle-input' });
 			cb.checked = !!checked;
 			cb.addEventListener('change', onChange);
-			var track = E('label', { 'class': 'tm-toggle', 'for': id });
-			return E('div', { 'class': 'tm-toggle-wrap' }, [
+			var track = E('label', { 'class': 'tc-toggle', 'for': id });
+			return E('div', { 'class': 'tc-toggle-wrap' }, [
 				cb, track,
-				E('label', { 'for': id, 'style': 'cursor:pointer;font-size:12px;user-select:none;color:var(--tm-text)' }, label)
+				E('label', { 'for': id, 'style': 'cursor:pointer;font-size:12px;user-select:none;color:currentColor' }, label)
 			]);
 		}
 		function mkLabel(t) {
-			return E('span', { 'class': 'tm-inline-label' }, t);
+			return E('span', { 'class': 'tc-inline-label' }, t);
 		}
 
 		function mkInlinePick(options, currentValue, onChange) {
-			var wrapper = E('span', {'class':'tm-inline-pick-wrapper'});
-			var display = E('span', {'class':'tm-inline-pick-display'});
-			var popup = E('div', {'class':'tm-inline-pick-popup tm-hidden'});
+			var wrapper = E('span', {'class':'tc-inline-pick-wrapper'});
+			var display = E('span', {'class':'tc-inline-pick-display'});
+			var popup = E('div', {'class':'tc-inline-pick-popup tc-hidden'});
 			var selectedValue = currentValue;
 
 			function updateDisplay() {
@@ -1710,17 +1385,17 @@ return view.extend({
 					var active = opt.v === selectedValue;
 					var item = E('div', {
 						'style': 'padding:4px 14px;cursor:pointer;font-size:12px;' +
-							(active ? 'color:var(--tm-proto);font-weight:600;background:var(--tm-hover)' : 'color:var(--tm-text)')
+							(active ? 'color:var(--tc-speed);font-weight:600;background:var(--tc-hover)' : 'color:currentColor')
 					}, opt.l);
 					item.addEventListener('mousedown', function(ev) {
 						ev.preventDefault();
 						selectedValue = opt.v;
 						updateDisplay();
-						popup.classList.add('tm-hidden');
+						popup.classList.add('tc-hidden');
 						onChange(opt.v);
 					});
-					item.addEventListener('mouseenter', function() { this.style.background = 'var(--tm-hover)'; });
-					item.addEventListener('mouseleave', function() { this.style.background = active ? 'var(--tm-hover)' : ''; });
+					item.addEventListener('mouseenter', function() { this.style.background = 'var(--tc-hover)'; });
+					item.addEventListener('mouseleave', function() { this.style.background = active ? 'var(--tc-hover)' : ''; });
 					popup.appendChild(item);
 				});
 			}
@@ -1728,9 +1403,9 @@ return view.extend({
 			display.addEventListener('click', function(ev) {
 				ev.stopPropagation();
 				buildPopup();
-				popup.classList.toggle('tm-hidden');
+				popup.classList.toggle('tc-hidden');
 			});
-			document.addEventListener('click', function() { popup.classList.add('tm-hidden'); });
+			document.addEventListener('click', function() { popup.classList.add('tc-hidden'); });
 
 			wrapper.appendChild(display);
 			wrapper.appendChild(popup);
@@ -1743,38 +1418,38 @@ return view.extend({
 			var selected = currentValue;
 			var chips = [];
 			options.forEach(function(opt) {
-				var chip = E('span', {'class': opt.v === selected ? 'tm-chip tm-chip--active' : 'tm-chip'}, opt.l);
+				var chip = E('span', {'class': opt.v === selected ? 'tc-chip tc-chip--active' : 'tc-chip'}, opt.l);
 				chip.addEventListener('click', function() {
 					selected = opt.v;
-					chips.forEach(function(c) { c.className = c._v === selected ? 'tm-chip tm-chip--active' : 'tm-chip'; });
+					chips.forEach(function(c) { c.className = c._v === selected ? 'tc-chip tc-chip--active' : 'tc-chip'; });
 					onChange(opt.v);
 				});
 				chip._v = opt.v;
 				chips.push(chip);
 				wrapper.appendChild(chip);
 			});
-			return { el: wrapper, getValue: function() { return selected; }, setValue: function(v) { selected = v; chips.forEach(function(c) { c.className = c._v === v ? 'tm-chip tm-chip--active' : 'tm-chip'; }); } };
+			return { el: wrapper, getValue: function() { return selected; }, setValue: function(v) { selected = v; chips.forEach(function(c) { c.className = c._v === v ? 'tc-chip tc-chip--active' : 'tc-chip'; }); } };
 		}
 
 		var showStats = mkToggle('tm-stats', _('Stats'), opts.showStats !== false, function() {
 			var o = loadOpts(); o.showStats = this.checked; saveOpts(o); updateUrlParams(o);
-			statsDiv.classList.toggle('tm-hidden', !this.checked);
+			statsDiv.classList.toggle('tc-hidden', !this.checked);
 		});
 		var showConns = mkToggle('tm-conns', _('Connections'), opts.showConns !== false, function() {
 			var o = loadOpts(); o.showConns = this.checked; saveOpts(o); updateUrlParams(o);
-			connsDiv.classList.toggle('tm-hidden', !this.checked);
+			connsDiv.classList.toggle('tc-hidden', !this.checked);
 		});
 		var rdnsCheck = mkToggle('tm-rdns', _('rDNS'), opts.rdns, function() {
 			var o = loadOpts(); o.rdns = this.checked; saveOpts(o); updateUrlParams(o);
 		});
 		var extStatsCheck = mkToggle('tm-extended', _('Extended'), opts.extendedStats, function() {
 			var o = loadOpts(); o.extendedStats = this.checked; saveOpts(o); updateUrlParams(o);
-			extStatsDiv.classList.toggle('tm-hidden', !this.checked);
+			extStatsDiv.classList.toggle('tc-hidden', !this.checked);
 			if (this.checked) updateExtendedStats();
 		});
 		var activityCheck = mkToggle('tm-activity', _('Activity'), opts.showActivity, function() {
 			var o = loadOpts(); o.showActivity = this.checked; saveOpts(o);
-			activityDiv.classList.toggle('tm-hidden', !this.checked);
+			activityDiv.classList.toggle('tc-hidden', !this.checked);
 			if (this.checked) {
 				if (!activityDiv._loaded) {
 					activityDiv._loaded = true;
@@ -1784,8 +1459,8 @@ return view.extend({
 			}
 		});
 
-		var extStatsDiv = E('div', { 'class': opts.extendedStats ? '' : 'tm-hidden' });
-		var activityDiv = E('div', { 'class': opts.showActivity ? '' : 'tm-hidden' });
+		var extStatsDiv = E('div', { 'class': opts.extendedStats ? '' : 'tc-hidden' });
+		var activityDiv = E('div', { 'class': opts.showActivity ? '' : 'tc-hidden' });
 
 		var refreshPick = mkChipPick([
 			{v:'0',l:_('Off')},{v:'5',l:'5s'},{v:'10',l:'10s'},{v:'30',l:'30s'},{v:'60',l:'60s'}
@@ -1823,9 +1498,9 @@ return view.extend({
 			var o = loadOpts(); o.groupBy = v; saveOpts(o); runQuery();
 		});
 
-		var statusDiv = E('div', { 'class': 'tm-hidden' });
-		var statsDiv  = E('div', { 'style': 'margin:8px 0', 'class': opts.showStats === false ? 'tm-hidden' : '' });
-		var connsDiv  = E('div', { 'class': opts.showConns === false ? 'tm-hidden' : '' });
+		var statusDiv = E('div', { 'class': 'tc-hidden' });
+		var statsDiv  = E('div', { 'style': 'margin:8px 0', 'class': opts.showStats === false ? 'tc-hidden' : '' });
+		var connsDiv  = E('div', { 'class': opts.showConns === false ? 'tc-hidden' : '' });
 
 		var _rdnsQueue   = [];
 		var _rdnsFlying  = 0;
@@ -1846,7 +1521,7 @@ return view.extend({
 							connsDiv.querySelectorAll('td[data-dst="'+it.dst+'"]'),
 							function(cell) {
 								if (host) { cell.textContent = host; cell.style.color = ''; }
-								else { cell.innerHTML = '<span class="tm-c-faint">—</span>'; }
+								else { cell.innerHTML = '<span class="tc-c-faint">—</span>'; }
 							}
 						);
 					}).catch(function() {
@@ -1856,7 +1531,7 @@ return view.extend({
 						self._rdnsCache[it.dst] = null;
 						Array.prototype.forEach.call(
 							connsDiv.querySelectorAll('td[data-dst="'+it.dst+'"]'),
-							function(cell) { cell.innerHTML = '<span class="tm-c-faint">—</span>'; }
+							function(cell) { cell.innerHTML = '<span class="tc-c-faint">—</span>'; }
 						);
 					});
 				})(item);
@@ -1864,7 +1539,7 @@ return view.extend({
 		};
 
 		// Speed graph popup on spark cell hover
-		var graphPopup = E('div', {'class':'tm-graph-popup tm-hidden'});
+		var graphPopup = E('div', {'class':'tc-graph-popup tc-hidden'});
 		document.body.appendChild(graphPopup);
 		var graphPopupIp = null;
 		var graphPopupTimer = null;
@@ -1877,7 +1552,7 @@ return view.extend({
 			var rect = cell.getBoundingClientRect();
 			graphPopup.style.left = Math.max(8, rect.left - 160) + 'px';
 			graphPopup.style.top = (rect.bottom + 6) + 'px';
-			graphPopup.classList.remove('tm-hidden');
+			graphPopup.classList.remove('tc-hidden');
 			if (!graphPopupTimer) {
 				graphPopupTimer = setInterval(updateGraphPopup, 2000);
 			}
@@ -1897,15 +1572,15 @@ return view.extend({
 			if (svg) {
 				graphPopup.appendChild(svg);
 				if (lk > 0) {
-					graphPopup.appendChild(E('div', {'class':'tm-graph-popup__note'},
+					graphPopup.appendChild(E('div', {'class':'tc-graph-popup__note'},
 						_('Note: speed is measured before shaper — bursts above limit are normal')));
 				}
 			} else {
-				graphPopup.appendChild(E('span', {'class':'tm-graph-popup__empty'}, _('Not enough data yet')));
+				graphPopup.appendChild(E('span', {'class':'tc-graph-popup__empty'}, _('Not enough data yet')));
 			}
 		}
 		function hideGraphPopup() {
-			graphPopup.classList.add('tm-hidden');
+			graphPopup.classList.add('tc-hidden');
 			graphPopupIp = null;
 			if (graphPopupTimer) { clearInterval(graphPopupTimer); graphPopupTimer = null; }
 		}
@@ -1925,32 +1600,32 @@ return view.extend({
 		}, true);
 
 		var inetBtn = E('button', { 'class': 'cbi-button' }, '');
-		var wifiBtn = E('button', { 'class': 'cbi-button tm-hidden' }, '');
+		var wifiBtn = E('button', { 'class': 'cbi-button tc-hidden' }, '');
 
 		function updateInetBtn(blocked) {
 			if (blocked) {
-				inetBtn.textContent = '▶️ ' + _('Unblock Internet');
-				inetBtn.className = 'tm-btn tm-btn--unblock';
+				inetBtn.textContent = _('Unblock Internet');
+				inetBtn.className = 'cbi-button cbi-button-positive';
 				inetBtn._action = 'unblock';
 			} else {
-				inetBtn.textContent = '⏸️ ' + _('Block Internet');
-				inetBtn.className = 'tm-btn tm-btn--block';
+				inetBtn.textContent = _('Block Internet');
+				inetBtn.className = 'cbi-button cbi-button-negative';
 				inetBtn._action = 'block';
 			}
 		}
 		updateInetBtn(false);
 
 		function updateWifiBtn(wifiBlocked, hasMac) {
-			if (!hasMac) { wifiBtn.classList.add('tm-hidden'); return; }
-			wifiBtn.classList.remove('tm-hidden');
+			if (!hasMac) { wifiBtn.classList.add('tc-hidden'); return; }
+			wifiBtn.classList.remove('tc-hidden');
 			wifiBtn.disabled = false;
 			if (wifiBlocked) {
-				wifiBtn.textContent = '📡✓ ' + _('Unblock WiFi');
-				wifiBtn.className = 'tm-btn tm-btn--unblock';
+				wifiBtn.textContent = _('Unblock WiFi');
+				wifiBtn.className = 'cbi-button cbi-button-positive';
 				wifiBtn._wifiAction = 'unblock';
 			} else {
-				wifiBtn.textContent = '📡❌ ' + _('Block WiFi');
-				wifiBtn.className = 'tm-btn tm-btn--block';
+				wifiBtn.textContent = _('Block WiFi');
+				wifiBtn.className = 'cbi-button cbi-button-negative';
 				wifiBtn._wifiAction = 'block';
 			}
 		}
@@ -1959,15 +1634,15 @@ return view.extend({
 		var _rateSelected = '0';
 		var _modeSelected = 'shaper';
 
-		var rateChipsRow = E('div', {'class':'tm-rate-chips-row'});
+		var rateChipsRow = E('div', {'class':'tc-chips-row'});
 		var rateChips = [];
 		RATE_PRESETS.filter(function(p) { return p.v !== 'custom'; }).forEach(function(preset) {
-			var chip = E('span', {'class': preset.v === '0' ? 'tm-chip tm-chip--off' : 'tm-chip'}, preset.l);
+			var chip = E('span', {'class': preset.v === '0' ? 'tc-chip tc-chip' : 'tc-chip'}, preset.l);
 			chip._val = preset.v;
 			chip.addEventListener('click', function() {
 				_rateSelected = preset.v;
 				updateRateChips();
-				customRow.classList.add('tm-hidden');
+				customRow.classList.add('tc-hidden');
 				applyRate();
 			});
 			rateChips.push(chip);
@@ -1977,28 +1652,28 @@ return view.extend({
 		function updateRateChips() {
 			rateChips.forEach(function(c) {
 				if (c._val === '0') {
-					c.className = c._val === _rateSelected ? 'tm-chip tm-chip--off-active' : 'tm-chip tm-chip--off';
+					c.className = c._val === _rateSelected ? 'tc-chip tc-chip--active' : 'tc-chip tc-chip';
 				} else {
-					c.className = c._val === _rateSelected ? 'tm-chip tm-chip--active' : 'tm-chip';
+					c.className = c._val === _rateSelected ? 'tc-chip tc-chip--active' : 'tc-chip';
 				}
 			});
 			if (_rateSelected === 'custom') {
-				rateChips.forEach(function(c) { c.className = c._val === '0' ? 'tm-chip tm-chip--off' : 'tm-chip'; });
+				rateChips.forEach(function(c) { c.className = c._val === '0' ? 'tc-chip tc-chip' : 'tc-chip'; });
 			}
 		}
 
 		// Custom input row
 		var customInput = E('input', { 'type':'number', 'min':'1', 'step':'1', 'placeholder': _('value'),
-			'class': 'tm-custom-input' });
-		var customUnitBtns = E('span', {'class':'tm-custom-unit-btns'});
+			'class': 'tc-custom-input' });
+		var customUnitBtns = E('span', {'class':'tc-custom-unit-btns'});
 		var _customUnit = 'mbit';
-		var mbitBtn = E('span', {'style':'padding:4px 8px;font-size:11px;cursor:pointer;background:var(--tm-proto);color:#fff'}, 'Mbit/s');
-		var kbitBtn = E('span', {'style':'padding:4px 8px;font-size:11px;cursor:pointer;background:var(--tm-bg);color:var(--tm-text)'}, 'kbit/s');
+		var mbitBtn = E('span', {'style':'padding:4px 8px;font-size:11px;cursor:pointer;background:var(--tc-speed);color:#fff'}, 'Mbit/s');
+		var kbitBtn = E('span', {'style':'padding:4px 8px;font-size:11px;cursor:pointer;background:var(--tc-bg);color:currentColor'}, 'kbit/s');
 		function updateUnitBtns() {
-			mbitBtn.style.background = _customUnit === 'mbit' ? 'var(--tm-proto)' : 'var(--tm-bg)';
-			mbitBtn.style.color = _customUnit === 'mbit' ? '#fff' : 'var(--tm-text)';
-			kbitBtn.style.background = _customUnit === 'kbit' ? 'var(--tm-proto)' : 'var(--tm-bg)';
-			kbitBtn.style.color = _customUnit === 'kbit' ? '#fff' : 'var(--tm-text)';
+			mbitBtn.style.background = _customUnit === 'mbit' ? 'var(--tc-speed)' : 'var(--tc-bg)';
+			mbitBtn.style.color = _customUnit === 'mbit' ? '#fff' : 'currentColor';
+			kbitBtn.style.background = _customUnit === 'kbit' ? 'var(--tc-speed)' : 'var(--tc-bg)';
+			kbitBtn.style.color = _customUnit === 'kbit' ? '#fff' : 'currentColor';
 		}
 		mbitBtn.addEventListener('click', function() { _customUnit = 'mbit'; updateUnitBtns(); });
 		kbitBtn.addEventListener('click', function() { _customUnit = 'kbit'; updateUnitBtns(); });
@@ -2006,7 +1681,7 @@ return view.extend({
 		customUnitBtns.appendChild(kbitBtn);
 
 		var customApplyBtn = E('button', {
-			'class':'tm-custom-apply'
+			'class':'cbi-button cbi-button-action'
 		}, _('Apply'));
 		customApplyBtn.addEventListener('click', function() {
 			_rateSelected = 'custom';
@@ -2014,32 +1689,32 @@ return view.extend({
 			applyRate();
 		});
 
-		var customToggleBtn = E('span', {'class': 'tm-chip', 'data-tip': _('Enter a custom speed value')}, '✎ ' + _('Custom'));
+		var customToggleBtn = E('span', {'class': 'tc-chip', 'data-tip': _('Enter a custom speed value')}, '✎ ' + _('Custom'));
 		customToggleBtn.addEventListener('click', function() {
-			customRow.classList.toggle('tm-hidden');
+			customRow.classList.toggle('tc-hidden');
 		});
 		rateChipsRow.appendChild(customToggleBtn);
 
-		var customRow = E('div', {'class':'tm-custom-row tm-hidden'}, [
+		var customRow = E('div', {'class':'tc-custom-row tc-hidden'}, [
 			customInput, customUnitBtns, customApplyBtn
 		]);
 
 		// Mode: segmented toggle (Shaper default)
-		var modeToggle = E('div', {'class':'tm-mode-toggle'});
+		var modeToggle = E('div', {'class':'tc-mode-toggle'});
 		var shaperBtn = E('span', {
 			'style':'padding:5px 12px;font-size:11px;font-weight:600;cursor:pointer;transition:all .15s',
 			'data-tip': _('Queues excess traffic (smoother streaming, lower jitter)')
-		}, '🌊 ' + _('Shaper'));
+		}, _('Shaper'));
 		var limiterBtn = E('span', {
 			'style':'padding:5px 12px;font-size:11px;font-weight:500;cursor:pointer;transition:all .15s',
 			'data-tip': _('Drops excess packets (instant enforcement, low overhead)')
-		}, '⚡ ' + _('Limiter'));
+		}, _('Limiter'));
 		function updateModeToggle() {
-			shaperBtn.style.background = _modeSelected === 'shaper' ? 'var(--tm-proto)' : 'var(--tm-bg)';
-			shaperBtn.style.color = _modeSelected === 'shaper' ? '#fff' : 'var(--tm-text)';
+			shaperBtn.style.background = _modeSelected === 'shaper' ? 'var(--tc-speed)' : 'var(--tc-bg)';
+			shaperBtn.style.color = _modeSelected === 'shaper' ? '#fff' : 'currentColor';
 			shaperBtn.style.fontWeight = _modeSelected === 'shaper' ? '600' : '500';
-			limiterBtn.style.background = _modeSelected === 'limiter' ? 'var(--tm-rate-fg, #e67e22)' : 'var(--tm-bg)';
-			limiterBtn.style.color = _modeSelected === 'limiter' ? '#fff' : 'var(--tm-text)';
+			limiterBtn.style.background = _modeSelected === 'limiter' ? 'var(--tc-warn)' : 'var(--tc-bg)';
+			limiterBtn.style.color = _modeSelected === 'limiter' ? '#fff' : 'currentColor';
 			limiterBtn.style.fontWeight = _modeSelected === 'limiter' ? '600' : '500';
 		}
 		shaperBtn.addEventListener('click', function() { _modeSelected = 'shaper'; updateModeToggle(); });
@@ -2049,10 +1724,10 @@ return view.extend({
 		updateModeToggle();
 
 		var rateLimitRow = E('div', {
-			'class': 'tm-rate-panel tm-hidden'
+			'class': 'tc-rate-panel tc-hidden'
 		}, [
-			E('div', {'class':'tm-rate-panel__header'}, [
-				E('span', {'class':'tm-rate-panel__title'}, '⚡ ' + _('Speed Limit')),
+			E('div', {'class':'tc-rate-panel__header'}, [
+				E('span', {'class':'tc-rate-panel__title'}, _('Speed Limit')),
 				modeToggle
 			]),
 			rateChipsRow,
@@ -2117,18 +1792,18 @@ return view.extend({
 			}
 		}
 
-		var actionRow = E('div', { 'class': 'tm-action-row' },
+		var actionRow = E('div', { 'class': 'tc-action-row' },
 			[inetBtn, wifiBtn]);
 
 		function isAllMode() { return searchSelect.getValue() === '__all__'; }
 
 		function updateModeUI() {
 			var all = isAllMode();
-			actionRow.classList.toggle('tm-hidden', all);
-			rateLimitRow.classList.toggle('tm-hidden', all);
-			rdnsCheck.classList.toggle('tm-hidden', all);
-			extStatsCheck.classList.toggle('tm-hidden', all);
-			extStatsDiv.classList.toggle('tm-hidden', all || !loadOpts().extendedStats);
+			actionRow.classList.toggle('tc-hidden', all);
+			rateLimitRow.classList.toggle('tc-hidden', all);
+			rdnsCheck.classList.toggle('tc-hidden', all);
+			extStatsCheck.classList.toggle('tc-hidden', all);
+			extStatsDiv.classList.toggle('tc-hidden', all || !loadOpts().extendedStats);
 			if (typeof updateTableSectionMode === 'function') updateTableSectionMode();
 		}
 
@@ -2144,9 +1819,9 @@ return view.extend({
 				var cell = connsDiv.querySelector('td[data-speed-ip="'+ip+'"]');
 				if (!cell) return;
 				if (s.current > 1024) {
-					cell.className = 'tm-speed-active';
+					cell.className = 'tc-speed-active';
 				} else {
-					cell.className = 'tm-speed-idle';
+					cell.className = 'tc-speed-idle';
 				}
 				cell.textContent = fmtSpeed(s.current);
 				cell.title = _('Avg')+': '+fmtSpeed(s.avg)+' / '+_('Max')+': '+fmtSpeed(s.max);
@@ -2179,11 +1854,11 @@ return view.extend({
 						while (cell.firstChild) cell.removeChild(cell.firstChild);
 						if (dp > 0) {
 							cell.appendChild(E('span', {
-								'class': 'tm-c-drop tm-fw-600',
+								'class': 'tc-c-err tc-fw-bold',
 								'title': fmtBytes(db) + ' ' + _('dropped')
-							}, '🚫 ' + dp));
+							}, String(dp)));
 						} else {
-							cell.appendChild(E('span', { 'class': 'tm-c-faint' }, '—'));
+							cell.appendChild(E('span', { 'class': 'tc-c-faint' }, '—'));
 						}
 					});
 				}
@@ -2211,9 +1886,9 @@ return view.extend({
 						if (!cell) return;
 						while (cell.firstChild) cell.removeChild(cell.firstChild);
 						if (bl > 0) {
-							cell.appendChild(E('span', { 'class': 'tm-c-shape tm-fw-600', 'title': _('Bytes queued in tc') }, fmtBytes(bl)));
+							cell.appendChild(E('span', { 'class': 'tc-c-speed tc-fw-bold', 'title': _('Bytes queued in tc') }, fmtBytes(bl)));
 						} else {
-							cell.appendChild(E('span', { 'class': 'tm-c-faint' }, '—'));
+							cell.appendChild(E('span', { 'class': 'tc-c-faint' }, '—'));
 						}
 					});
 				}
@@ -2337,21 +2012,21 @@ return view.extend({
 						}
 					}
 					if ((data.shape_kbit || 0) > 0) {
-						parts.push(_('Shaped') + ': <b style="color:var(--tm-shape-fg)">🌊 '+fmtRate(data.shape_kbit)+'</b>');
+						parts.push(_('Shaped') + ': <b style="color:var(--tc-speed)">🌊 '+fmtRate(data.shape_kbit)+'</b>');
 						var sm = self._shapeMap[data.ip || searchSelect.getValue()] || {};
-						if ((sm.backlog||0) > 0) parts.push(_('Queued') + ': <b style="color:var(--tm-shape-fg)">'+fmtBytes(sm.backlog)+'</b>');
+						if ((sm.backlog||0) > 0) parts.push(_('Queued') + ': <b style="color:var(--tc-speed)">'+fmtBytes(sm.backlog)+'</b>');
 						if ((sm.bytes||0) > 0) parts.push(_('Passed') + ': <b>'+fmtBytes(sm.bytes)+'</b>');
 					} else if ((data.rate_limit_kbit || 0) > 0) {
-						parts.push(_('Speed limit') + ': <b style="color:var(--tm-rate-fg)">⚡ '+fmtRate(data.rate_limit_kbit)+'</b>');
+						parts.push(_('Speed limit') + ': <b style="color:var(--tc-warn)">⚡ '+fmtRate(data.rate_limit_kbit)+'</b>');
 						var dm = self._dropMap[data.ip || searchSelect.getValue()] || {};
 						if ((dm.packets||0) > 0) {
-							parts.push(_('Dropped') + ': <b style="color:var(--tm-drop-fg)">🚫 '+dm.packets+' pkts / '+fmtBytes(dm.bytes||0)+'</b>');
+							parts.push(_('Dropped') + ': <b style="color:var(--tc-err)">🚫 '+dm.packets+' pkts / '+fmtBytes(dm.bytes||0)+'</b>');
 						}
 					}
 					var wifiPart = data.wifi_blocked
-						? ' &nbsp;|&nbsp; <b style="color:var(--tm-state-wait)">📵 ' + _('WiFi blocked') + '</b> ('+escHtml(data.mac||'') + ')'
-						: (data.mac ? ' &nbsp;|&nbsp; <span style="color:var(--tm-text-faint)">MAC: '+escHtml(data.mac)+'</span>' : '');
-					statsDiv.className = 'tm-stats-bar ' + (data.blocked ? 'tm-stats-bar--blocked' : 'tm-stats-bar--info');
+						? ' &nbsp;|&nbsp; <b style="color:var(--tc-warn)">📵 ' + _('WiFi blocked') + '</b> ('+escHtml(data.mac||'') + ')'
+						: (data.mac ? ' &nbsp;|&nbsp; <span style="color:var(--tc-faint)">MAC: '+escHtml(data.mac)+'</span>' : '');
+					statsDiv.className = 'alert-message ' + (data.blocked ? 'error' : 'info');
 					statsDiv.innerHTML = (data.blocked
 						? '<b>⛔ ' + _('BLOCKED') + '</b> — '+data.block_packets+' pkts, '+fmtBytes(data.block_bytes)+' ' + _('dropped') + ' &nbsp;|&nbsp; '
 						: '') + parts.join(' &nbsp;|&nbsp; ') + wifiPart;
@@ -2369,20 +2044,20 @@ return view.extend({
 				var matched = RATE_PRESETS.some(function(p) { return p.v === curRateStr; });
 				if (matched) {
 					ratePick.setValue(curRateStr);
-					customRow.classList.add('tm-hidden');
+					customRow.classList.add('tc-hidden');
 				} else if (curRate > 0) {
 					ratePick.setValue('custom');
 					customInput.value = curRate;
 					_customUnit = 'kbit'; updateUnitBtns();
-					customRow.classList.remove('tm-hidden');
+					customRow.classList.remove('tc-hidden');
 				} else {
 					ratePick.setValue('0');
-					customRow.classList.add('tm-hidden');
+					customRow.classList.add('tc-hidden');
 				}
 
 				while (connsDiv.firstChild) connsDiv.removeChild(connsDiv.firstChild);
 				if (!data.connections || data.connections.length === 0) {
-					connsDiv.appendChild(E('p', {'style':'color:var(--tm-text-mute);padding:12px 0'}, _('No active connections.')));
+					connsDiv.appendChild(E('p', {'style':'color:var(--tc-muted);padding:12px 0'}, _('No active connections.')));
 				} else {
 					var groupBy = o.groupBy || 'none';
 					var tbl;
@@ -2402,7 +2077,7 @@ return view.extend({
 							});
 						});
 						connsDiv.appendChild(E('div',{'style':'overflow-x:auto'},[tbl]));
-						connsDiv.appendChild(E('p',{'style':'color:var(--tm-text-faint);font-size:11px;margin-top:6px'},
+						connsDiv.appendChild(E('p',{'style':'color:var(--tc-faint);font-size:11px;margin-top:6px'},
 							groups.length + ' ' + _('groups from') + ' ' + data.connections.length + ' ' + _('connections') + '. ' + _('Click header to sort.')));
 					} else {
 						tbl = buildTable(data.connections, self._sortCol, self._sortDir, o.rdns, self._connHiddenCols);
@@ -2419,7 +2094,7 @@ return view.extend({
 							});
 						});
 						connsDiv.appendChild(E('div',{'style':'overflow-x:auto'},[tbl]));
-						connsDiv.appendChild(E('p',{'style':'color:var(--tm-text-faint);font-size:11px;margin-top:6px'},
+						connsDiv.appendChild(E('p',{'style':'color:var(--tc-faint);font-size:11px;margin-top:6px'},
 							data.connections.length + ' ' + _('connections') + '. ' + _('Click header to sort.')));
 
 						if (o.rdns) {
@@ -2436,7 +2111,7 @@ return view.extend({
 										connsDiv.querySelectorAll('td[data-dst="'+dst+'"]'),
 										function(cell) {
 											if (cached) { cell.textContent = cached; cell.style.color = ''; }
-											else { cell.innerHTML = '<span class="tm-c-faint">—</span>'; }
+											else { cell.innerHTML = '<span class="tc-c-faint">—</span>'; }
 										}
 									);
 									return;
@@ -2481,7 +2156,7 @@ return view.extend({
 			var lnk = 'cursor:pointer;text-decoration:underline;text-decoration-style:dashed';
 			var activeFilter = self._tableFilter;
 
-			statsDiv.className = 'tm-stats-bar tm-stats-bar--info';
+			statsDiv.className = 'alert-message info';
 			while (statsDiv.firstChild) statsDiv.removeChild(statsDiv.firstChild);
 
 			function mkFilterVal(filter, color, text) {
@@ -2492,16 +2167,16 @@ return view.extend({
 
 			var parts = [];
 			parts.push(E('span', {}, [document.createTextNode(_('Active') + ': '), E('b', {}, String(rows.length))]));
-			parts.push(E('span', {}, [document.createTextNode(_('Blocked') + ': '), mkFilterVal('blocked', 'var(--tm-blocked-fg)', String(blocked))]));
-			parts.push(E('span', {}, [document.createTextNode(_('WiFi') + ': '), mkFilterVal('wifi_blocked', 'var(--tm-state-wait)', String(wifiBlk))]));
-			if (limited > 0) parts.push(E('span', {}, [document.createTextNode(_('Limited') + ': '), mkFilterVal('limited', 'var(--tm-rate-fg)', '⚡' + limited)]));
-			if (shaped > 0) parts.push(E('span', {}, [document.createTextNode(_('Shaped') + ': '), mkFilterVal('shaped', 'var(--tm-shape-fg)', '🌊' + shaped)]));
+			parts.push(E('span', {}, [document.createTextNode(_('Blocked') + ': '), mkFilterVal('blocked', 'var(--tc-err)', String(blocked))]));
+			parts.push(E('span', {}, [document.createTextNode(_('WiFi') + ': '), mkFilterVal('wifi_blocked', 'var(--tc-warn)', String(wifiBlk))]));
+			if (limited > 0) parts.push(E('span', {}, [document.createTextNode(_('Limited') + ': '), mkFilterVal('limited', 'var(--tc-warn)', '⚡' + limited)]));
+			if (shaped > 0) parts.push(E('span', {}, [document.createTextNode(_('Shaped') + ': '), mkFilterVal('shaped', 'var(--tc-speed)', '🌊' + shaped)]));
 			if (totalDropPkts > 0) parts.push(E('span', {}, [
-				document.createTextNode(_('Dropped') + ': '), E('b', {'style':'color:var(--tm-drop-fg)'}, '🚫' + totalDropPkts)
+				document.createTextNode(_('Dropped') + ': '), E('b', {'style':'color:var(--tc-err)'}, '🚫' + totalDropPkts)
 			]));
 
 			parts.forEach(function(el, i) {
-				if (i > 0) statsDiv.appendChild(E('span', {'style':'margin:0 6px;color:var(--tm-text-faint)'}, '|'));
+				if (i > 0) statsDiv.appendChild(E('span', {'style':'margin:0 6px;color:var(--tc-faint)'}, '|'));
 				statsDiv.appendChild(el);
 				var filterEl = el.querySelector('[data-filter]');
 				if (filterEl) {
@@ -2510,14 +2185,14 @@ return view.extend({
 			});
 
 			if (activeFilter) {
-				statsDiv.appendChild(E('span', {'style':'margin-left:10px;cursor:pointer;color:var(--tm-text-mute);font-size:11px'}, '✕ ' + _('clear filter')));
+				statsDiv.appendChild(E('span', {'style':'margin-left:10px;cursor:pointer;color:var(--tc-muted);font-size:11px'}, '✕ ' + _('clear filter')));
 				statsDiv.lastChild.addEventListener('click', function() { self._tableFilter = null; renderSummary(rows); });
 			}
 
 			var filtered = applyTableFilter(rows);
 			while (connsDiv.firstChild) connsDiv.removeChild(connsDiv.firstChild);
 			if (filtered.length === 0) {
-				connsDiv.appendChild(E('p',{'style':'color:var(--tm-text-mute);padding:12px 0'}, _('No devices match filter.')));
+				connsDiv.appendChild(E('p',{'style':'color:var(--tc-muted);padding:12px 0'}, _('No devices match filter.')));
 			} else {
 				var tbl = buildSummaryTable(
 					filtered,
@@ -2547,7 +2222,7 @@ return view.extend({
 					self._hiddenCols
 				);
 				connsDiv.appendChild(E('div',{'style':'overflow-x:auto'},[tbl]));
-				connsDiv.appendChild(E('p',{'style':'color:var(--tm-text-faint);font-size:11px;margin-top:6px'},
+				connsDiv.appendChild(E('p',{'style':'color:var(--tc-faint);font-size:11px;margin-top:6px'},
 					_('Click a row to inspect that device. Download speed updates every 2 seconds.')));
 			}
 		}
@@ -2665,15 +2340,15 @@ return view.extend({
 			{key:'_throttle_kbit', label:_('Speed Limit')},
 			{key:'_drop_packets', label:_('Drops')}, {key:'_backlog', label:_('Queue')}
 		];
-		var colChipsContainer = E('div', {'class':'tm-chips-wrap'});
+		var colChipsContainer = E('div', {'class':'tc-chips-wrap'});
 		colChipDefs.forEach(function(ct) {
 			var chip = E('span', {
-				'class': savedHidden[ct.key] ? 'tm-col-chip tm-col-chip--off' : 'tm-col-chip tm-col-chip--on',
+				'class': savedHidden[ct.key] ? 'tc-col-chip tc-col-chip--off' : 'tc-col-chip tc-col-chip--on',
 				'data-tip': _('Click to toggle column visibility')
 			}, ct.label);
 			chip.addEventListener('click', function() {
-				if (self._hiddenCols[ct.key]) { delete self._hiddenCols[ct.key]; chip.className = 'tm-col-chip tm-col-chip--on'; }
-				else { self._hiddenCols[ct.key] = true; chip.className = 'tm-col-chip tm-col-chip--off'; }
+				if (self._hiddenCols[ct.key]) { delete self._hiddenCols[ct.key]; chip.className = 'tc-col-chip tc-col-chip--on'; }
+				else { self._hiddenCols[ct.key] = true; chip.className = 'tc-col-chip tc-col-chip--off'; }
 				var o = loadOpts(); o.hiddenCols = self._hiddenCols; saveOpts(o);
 				if (isAllMode()) runAll();
 			});
@@ -2689,45 +2364,45 @@ return view.extend({
 		];
 		var savedConnHidden = opts.connHiddenCols || {};
 		self._connHiddenCols = savedConnHidden;
-		var connColChipsContainer = E('div', {'class':'tm-chips-wrap'});
+		var connColChipsContainer = E('div', {'class':'tc-chips-wrap'});
 		connColDefs.forEach(function(ct) {
 			var chip = E('span', {
-				'class': savedConnHidden[ct.key] ? 'tm-col-chip tm-col-chip--off' : 'tm-col-chip tm-col-chip--on',
+				'class': savedConnHidden[ct.key] ? 'tc-col-chip tc-col-chip--off' : 'tc-col-chip tc-col-chip--on',
 				'data-tip': _('Click to toggle column visibility')
 			}, ct.label);
 			chip.addEventListener('click', function() {
-				if (self._connHiddenCols[ct.key]) { delete self._connHiddenCols[ct.key]; chip.className = 'tm-col-chip tm-col-chip--on'; }
-				else { self._connHiddenCols[ct.key] = true; chip.className = 'tm-col-chip tm-col-chip--off'; }
+				if (self._connHiddenCols[ct.key]) { delete self._connHiddenCols[ct.key]; chip.className = 'tc-col-chip tc-col-chip--on'; }
+				else { self._connHiddenCols[ct.key] = true; chip.className = 'tc-col-chip tc-col-chip--off'; }
 				var o = loadOpts(); o.connHiddenCols = self._connHiddenCols; saveOpts(o);
 				if (!isAllMode()) runQuery();
 			});
 			connColChipsContainer.appendChild(chip);
 		});
 
-		var sep = function() { return E('span', {'class':'tm-sep'}); };
-		var sectionLabel = function(t) { return E('div', {'class':'tm-section-label'}, t); };
+		var sep = function() { return E('span', {'class':'tc-sep'}); };
+		var sectionLabel = function(t) { return E('div', {'class':'tc-section-label'}, t); };
 
-		var settingsBody = E('div', {'class':'tm-settings-body'});
+		var settingsBody = E('div', {'class':'tc-settings-body'});
 		var settingsCollapsed = true;
-		var settingsToggle = E('div', {'class':'tm-settings-toggle'}, [E('span', {'class':'tm-settings-arrow'}, '▸'), E('span', {}, _('Settings'))]);
+		var settingsToggle = E('div', {'class':'tc-settings-toggle'}, [E('span', {}, '▸'), E('span', {}, _('Settings'))]);
 
 		settingsToggle.addEventListener('click', function() {
 			settingsCollapsed = !settingsCollapsed;
-			settingsBody.classList.toggle('tm-hidden', settingsCollapsed);
+			settingsBody.classList.toggle('tc-hidden', settingsCollapsed);
 			settingsToggle.firstChild.textContent = settingsCollapsed ? '▸' : '▾';
 		});
 
 		// ── Collapsible subsection helper ──────────────────────────────────
 		function mkCollapsible(title, content, startOpen) {
-			var body = E('div', {'class': 'tm-collapsible-body' + (startOpen ? '' : ' tm-hidden')});
+			var body = E('div', {'class': 'tc-collapsible-body' + (startOpen ? '' : ' tc-hidden')});
 			if (content) body.appendChild(content);
-			var arrow = E('span', {'class':'tm-c-mute', 'style':'font-size:11px'}, startOpen ? ' ▾' : ' ▸');
+			var arrow = E('span', {'class':'tc-c-muted', 'style':'font-size:11px'}, startOpen ? ' ▾' : ' ▸');
 			var label = sectionLabel(title);
 			label.style.cursor = 'pointer';
 			label.appendChild(arrow);
 			label.addEventListener('click', function() {
-				var open = !body.classList.contains('tm-hidden');
-				body.classList.toggle('tm-hidden');
+				var open = !body.classList.contains('tc-hidden');
+				body.classList.toggle('tc-hidden');
 				arrow.textContent = open ? ' ▸' : ' ▾';
 			});
 			return {label: label, body: body, el: E('div', {}, [label, body])};
@@ -2737,14 +2412,14 @@ return view.extend({
 		var tgSection = mkCollapsible(_('Telegram Bot'), null, false);
 		var tgLoaded = false;
 		tgSection.label.addEventListener('click', function() {
-			if (!tgLoaded && !tgSection.body.classList.contains('tm-hidden')) {
+			if (!tgLoaded && !tgSection.body.classList.contains('tc-hidden')) {
 				tgLoaded = true;
 				loadTelegramUI(tgSection.body);
 			}
 		});
 
 		function loadTelegramUI(container) {
-			var statusSpan = E('span', {'style':'font-size:12px;margin-left:8px;color:var(--tm-text-mute)'}, _('Loading…'));
+			var statusSpan = E('span', {'style':'font-size:12px;margin-left:8px;color:var(--tc-muted)'}, _('Loading…'));
 			container.appendChild(statusSpan);
 
 			callTelegramGet().then(function(cfg) {
@@ -2762,7 +2437,7 @@ return view.extend({
 					if (saveTimer) clearTimeout(saveTimer);
 					saveTimer = setTimeout(function() {
 						saveStatus.textContent = _('Saving…');
-						saveStatus.style.color = 'var(--tm-text-mute)';
+						saveStatus.style.color = 'var(--tc-muted)';
 						var tk = tokenInput.value;
 						if (tk === '' && cfg.bot_token_set) tk = '***';
 						var inetEl = container.querySelector('#tm-tg-inet');
@@ -2785,7 +2460,7 @@ return view.extend({
 						).then(function(res) {
 							if (res && res.ok) {
 								saveStatus.textContent = '✓';
-								saveStatus.style.color = 'var(--tm-state-ok)';
+								saveStatus.style.color = 'var(--tc-ok)';
 								cfg.bot_token_set = !!(tk && tk !== '***') || cfg.bot_token_set;
 								if (tk && tk !== '***') {
 									tokenInput.value = '';
@@ -2794,11 +2469,11 @@ return view.extend({
 								}
 							} else {
 								saveStatus.textContent = '✗ ' + (res && res.msg || 'error');
-								saveStatus.style.color = 'var(--tm-blocked-fg)';
+								saveStatus.style.color = 'var(--tc-err)';
 							}
 						}).catch(function(e) {
 							saveStatus.textContent = '✗ ' + e.message;
-							saveStatus.style.color = 'var(--tm-blocked-fg)';
+							saveStatus.style.color = 'var(--tc-err)';
 						});
 					}, 600);
 				};
@@ -2837,14 +2512,14 @@ return view.extend({
 				testBtn.addEventListener('click', function() {
 					testBtn.disabled = true;
 					testResult.textContent = _('Sending…');
-					testResult.style.color = 'var(--tm-text-mute)';
+					testResult.style.color = 'var(--tc-muted)';
 					var tk = tokenInput.value || '***';
 					callTelegramTest(tk, chatInput.value, templateArea.value || '').then(function(res) {
 						testResult.textContent = (res && res.ok) ? '✓ ' + (res.msg || 'OK') : '✗ ' + (res && res.msg || 'error');
-						testResult.style.color = (res && res.ok) ? 'var(--tm-state-ok)' : 'var(--tm-blocked-fg)';
+						testResult.style.color = (res && res.ok) ? 'var(--tc-ok)' : 'var(--tc-err)';
 					}).catch(function(e) {
 						testResult.textContent = '✗ ' + e.message;
-						testResult.style.color = 'var(--tm-blocked-fg)';
+						testResult.style.color = 'var(--tc-err)';
 					}).then(function() { testBtn.disabled = false; });
 				});
 				section.appendChild(E('div', {'class':'tg-row'}, [
@@ -2862,7 +2537,7 @@ return view.extend({
 					controlMode = ctrl;
 					segControl.className = 'tg-segmented__item' + (ctrl ? ' tg-segmented__item--active' : '');
 					segNotify.className = 'tg-segmented__item' + (!ctrl ? ' tg-segmented__item--active' : '');
-					controlSection.classList.toggle('tm-hidden', !ctrl);
+					controlSection.classList.toggle('tc-hidden', !ctrl);
 					doSave();
 				}
 
@@ -2919,7 +2594,7 @@ return view.extend({
 				};
 				renderPreview();
 
-				var varRef = E('div', {'style':'font-size:12px;line-height:1.7;color:var(--tm-text)'}, [
+				var varRef = E('div', {'style':'font-size:12px;line-height:1.7;color:currentColor'}, [
 					E('div', {'style':'font-weight:600;margin-bottom:4px'}, _('Variables')),
 					E('div', {}, [E('code', {}, '{{ name }}'), document.createTextNode(' — ' + _('device hostname'))]),
 					E('div', {}, [E('code', {}, '{{ ip }}'), document.createTextNode(' — ' + _('IP address'))]),
@@ -2938,7 +2613,7 @@ return view.extend({
 					E('div', {}, [E('code', {}, '{{ wan_ip }}'), document.createTextNode(' — ' + _('WAN IP'))]),
 					E('div', {}, [E('code', {}, '{{ load }}'), document.createTextNode(' — ' + _('CPU load (1 min)'))]),
 					E('div', {}, [E('code', {}, '{{ conns }}'), document.createTextNode(' — ' + _('device connections'))]),
-					E('div', {'style':'margin-top:6px;color:var(--tm-text-mute);font-size:11px'}, [
+					E('div', {'style':'margin-top:6px;color:var(--tc-muted);font-size:11px'}, [
 						document.createTextNode(_('HTML:') + ' '),
 						E('code', {}, '<b>'), document.createTextNode(' '),
 						E('code', {}, '<i>'), document.createTextNode(' '),
@@ -2949,9 +2624,9 @@ return view.extend({
 				]);
 
 				var templateToggle = E('span', {
-					'style': 'font-size:12px;cursor:pointer;color:var(--tm-text-mute);user-select:none'
+					'style': 'font-size:12px;cursor:pointer;color:var(--tc-muted);user-select:none'
 				}, '▸ ' + _('Customize message'));
-				var templateBody = E('div', {'class':'tm-hidden','style':'margin-top:6px'});
+				var templateBody = E('div', {'class':'tc-hidden','style':'margin-top:6px'});
 				templateBody.appendChild(E('div', {'style':'display:flex;gap:14px;align-items:flex-start;flex-wrap:wrap'}, [
 					E('div', {'style':'flex:1;min-width:200px'}, [templateArea]),
 					varRef
@@ -2961,8 +2636,8 @@ return view.extend({
 					previewBubble
 				]));
 				templateToggle.addEventListener('click', function() {
-					var show = templateBody.classList.contains('tm-hidden');
-					templateBody.classList.toggle('tm-hidden');
+					var show = templateBody.classList.contains('tc-hidden');
+					templateBody.classList.toggle('tc-hidden');
 					templateToggle.textContent = (show ? '▾ ' : '▸ ') + _('Customize message');
 				});
 				notifySection.appendChild(E('div', {'style':'margin-top:8px'}, [templateToggle, templateBody]));
@@ -2988,7 +2663,7 @@ return view.extend({
 					var limitOn = limitEl ? limitEl.checked : cfg.btn_limiter;
 					var shapeOn = shapeEl ? shapeEl.checked : cfg.btn_shaper;
 					if (!inetOn && !wifiOn && !limitOn && !shapeOn) {
-						kbdBubble.appendChild(E('div', {'style':'font-size:11px;color:var(--tm-text-faint);padding:4px'}, _('No action buttons enabled')));
+						kbdBubble.appendChild(E('div', {'style':'font-size:11px;color:var(--tc-faint);padding:4px'}, _('No action buttons enabled')));
 						return;
 					}
 					var row1 = [];
@@ -2999,7 +2674,7 @@ return view.extend({
 						var limitBtns = [];
 						RATE_PRESETS.forEach(function(p) {
 							if (p.v === '0' || p.v === 'custom') return;
-							limitBtns.push(E('span', {'class':'tg-kbd-btn'}, '⚡ ' + p.l.replace(' Mbit/s', 'M').replace(/\s/g, '')));
+							limitBtns.push(E('span', {'class':'tg-kbd-btn'},  + p.l.replace(' Mbit/s', 'M').replace(/\s/g, '')));
 						});
 						for (var li = 0; li < limitBtns.length; li += 3) {
 							kbdBubble.appendChild(E('div', {'class':'tg-kbd-row'}, limitBtns.slice(li, li + 3)));
@@ -3034,24 +2709,24 @@ return view.extend({
 						E('div', {}, [E('code', {}, '/status'), document.createTextNode(' — ' + _('all active blocks, limits, and shapes'))]),
 						E('div', {}, [E('code', {}, '/help'), document.createTextNode(' — ' + _('command list and bot mode'))])
 					]),
-					E('div', {'style':'font-size:10px;color:var(--tm-text-faint);margin-top:4px'},
+					E('div', {'style':'font-size:10px;color:var(--tc-faint);margin-top:4px'},
 						_('Flow: /devices → select device → inline keyboard with enabled actions above'))
 				]));
 
-				if (!controlMode) controlSection.classList.add('tm-hidden');
+				if (!controlMode) controlSection.classList.add('tc-hidden');
 				section.appendChild(controlSection);
 				section.appendChild(notifySection);
 				setupDone = true;
 			}).catch(function(e) {
 				statusSpan.textContent = '✗ ' + e.message;
-				statusSpan.style.color = 'var(--tm-blocked-fg)';
+				statusSpan.style.color = 'var(--tc-err)';
 			});
 		}
 
 		// ── Assemble settings sections ─────────────────────────────────────
 		settingsBody.appendChild(tgSection.el);
 
-		var displaySection = mkCollapsible(_('Display'), E('div', {'class':'tm-settings-section-row'}, [
+		var displaySection = mkCollapsible(_('Display'), E('div', {'class':'tc-settings-section-row'}, [
 			showStats, showConns, extStatsCheck, rdnsCheck, activityCheck,
 			sep(),
 			E('span', {'data-tip':_('Auto-refresh interval for summary table')}, [mkLabel(_('Refresh')+':'), refreshPick.el])
@@ -3062,14 +2737,14 @@ return view.extend({
 		var loggingSection = mkCollapsible(_('Logging & Persistence'), null, false);
 		var loggingLoaded = false;
 		loggingSection.label.addEventListener('click', function() {
-			if (!loggingLoaded && !loggingSection.body.classList.contains('tm-hidden')) {
+			if (!loggingLoaded && !loggingSection.body.classList.contains('tc-hidden')) {
 				loggingLoaded = true;
 				loadLoggingUI(loggingSection.body);
 			}
 		});
 
 		function loadLoggingUI(container) {
-			var statusSpan = E('span', {'style':'font-size:12px;color:var(--tm-text-mute)'}, _('Loading…'));
+			var statusSpan = E('span', {'style':'font-size:12px;color:var(--tc-muted)'}, _('Loading…'));
 			container.appendChild(statusSpan);
 
 			callLoggingGet().then(function(cfg) {
@@ -3081,7 +2756,7 @@ return view.extend({
 					if (logTimer) clearTimeout(logTimer);
 					logTimer = setTimeout(function() {
 						logStatus.textContent = _('Saving…');
-						logStatus.style.color = 'var(--tm-text-mute)';
+						logStatus.style.color = 'var(--tc-muted)';
 						callLoggingSet(
 							container.querySelector('#tm-log-enabled').checked,
 							null, null,
@@ -3094,10 +2769,10 @@ return view.extend({
 							container.querySelector('#tm-persist-rules').checked
 						).then(function(res) {
 							logStatus.textContent = (res && res.ok) ? '✓' : '✗';
-							logStatus.style.color = (res && res.ok) ? 'var(--tm-state-ok)' : 'var(--tm-blocked-fg)';
+							logStatus.style.color = (res && res.ok) ? 'var(--tc-ok)' : 'var(--tc-err)';
 						}).catch(function(e) {
 							logStatus.textContent = '✗';
-							logStatus.style.color = 'var(--tm-blocked-fg)';
+							logStatus.style.color = 'var(--tc-err)';
 						});
 					}, 400);
 				};
@@ -3112,32 +2787,32 @@ return view.extend({
 				var logTelegram = mkToggle('tm-log-telegram', _('Telegram'), cfg.log_telegram, doLogSave);
 				var logConfig = mkToggle('tm-log-config', _('Config'), cfg.log_config, doLogSave);
 
-				container.appendChild(E('div', {'class':'tm-log-row'}, [logEnabled, logSyslog, persistRules, logStatus]));
+				container.appendChild(E('div', {'class':'tc-log-row'}, [logEnabled, logSyslog, persistRules, logStatus]));
 				container.appendChild(E('div', {'style':'margin-top:6px'}, [
-					E('div', {'style':'font-size:11px;color:var(--tm-text-mute);margin-bottom:4px'}, _('Log categories')),
-					E('div', {'class':'tm-log-row'}, [logBlocks, logRatelimits, logShapes, logTelegram, logConfig])
+					E('div', {'style':'font-size:11px;color:var(--tc-muted);margin-bottom:4px'}, _('Log categories')),
+					E('div', {'class':'tc-log-row'}, [logBlocks, logRatelimits, logShapes, logTelegram, logConfig])
 				]));
 			}).catch(function(e) {
 				statusSpan.textContent = '✗ ' + e.message;
-				statusSpan.style.color = 'var(--tm-blocked-fg)';
+				statusSpan.style.color = 'var(--tc-err)';
 			});
 		}
 		settingsBody.appendChild(loggingSection.el);
 
-		var connFiltersRow = E('div', {'class':'tm-conn-filters-row'}, [
+		var connFiltersRow = E('div', {'class':'tc-conn-filters-row'}, [
 			E('span', {'data-tip':_('Filter connections by protocol')}, [mkLabel(_('Proto')+':'), protoPick.el]),
 			sep(),
 			E('span', {'data-tip':_('Group connections table rows')}, [mkLabel(_('Group')+':'), groupPick.el])
 		]);
-		var tableSection = mkCollapsible(_('Table & Speed'), E('div', {'class':'tm-table-speed-inner'}, [
-			E('div', {'class':'tm-table-speed-row'}, [
+		var tableSection = mkCollapsible(_('Table & Speed'), E('div', {'class':'tc-table-speed-inner'}, [
+			E('div', {'class':'tc-table-speed-row'}, [
 				E('span', {'data-tip':_('Polling interval for per-device speed graph')}, [mkLabel(_('Poll')+':'), pollIntervalPick.el]),
 				sep(),
 				E('span', {'data-tip':_('Time window for speed averaging')}, [mkLabel(_('Window')+':'), avgWindowPick.el]),
 				sep(),
 				E('span', {'data-tip':_('Simple = arithmetic mean, EWMA = exponential weighted moving average')}, [mkLabel(_('Method')+':'), avgMethodPick.el])
 			]),
-			E('div', {'style':'font-size:11px;color:var(--tm-text-mute);margin-bottom:4px'}, _('Visible columns')),
+			E('div', {'style':'font-size:11px;color:var(--tc-muted);margin-bottom:4px'}, _('Visible columns')),
 			colChipsContainer,
 			connColChipsContainer,
 			connFiltersRow
@@ -3146,29 +2821,29 @@ return view.extend({
 
 		function updateTableSectionMode() {
 			var all = isAllMode();
-			colChipsContainer.classList.toggle('tm-hidden', !all);
-			connColChipsContainer.classList.toggle('tm-hidden', all);
-			connFiltersRow.classList.toggle('tm-hidden', all);
+			colChipsContainer.classList.toggle('tc-hidden', !all);
+			connColChipsContainer.classList.toggle('tc-hidden', all);
+			connFiltersRow.classList.toggle('tc-hidden', all);
 		}
 		updateTableSectionMode();
 
-		var settingsPanel = E('div', {'class':'tm-settings-panel'}, [settingsToggle, settingsBody]);
+		var settingsPanel = E('div', {'class':'tc-settings-panel'}, [settingsToggle, settingsBody]);
 
 		function loadActivityPanel(container) {
-			container.className = 'tm-activity-panel';
-			var statusSpan = E('span', {'style':'font-size:12px;color:var(--tm-text-mute)'}, _('Loading…'));
+			container.className = 'tc-activity-panel';
+			var statusSpan = E('span', {'style':'font-size:12px;color:var(--tc-muted)'}, _('Loading…'));
 			container.appendChild(statusSpan);
 
 			callActivityLog(100).then(function(res) {
 				while (container.firstChild) container.removeChild(container.firstChild);
 				if (!res || !res.lines || !res.lines.length) {
-					container.appendChild(E('div', {'style':'font-size:12px;color:var(--tm-text-mute)'}, _('No activity recorded yet.')));
+					container.appendChild(E('div', {'style':'font-size:12px;color:var(--tc-muted)'}, _('No activity recorded yet.')));
 					return;
 				}
-				var logArea = E('div', {'class':'tm-log-area'});
+				var logArea = E('div', {'class':'tc-log-area'});
 				var lines = res.lines.slice().reverse();
 				lines.forEach(function(line) {
-					logArea.appendChild(E('div', {'class':'tm-log-line'}, line));
+					logArea.appendChild(E('div', {'class':'tc-log-line'}, line));
 				});
 				var refreshBtn = E('button', {
 					'class': 'cbi-button',
@@ -3183,7 +2858,7 @@ return view.extend({
 				container.appendChild(refreshBtn);
 			}).catch(function(e) {
 				statusSpan.textContent = '✗ ' + e.message;
-				statusSpan.style.color = 'var(--tm-blocked-fg)';
+				statusSpan.style.color = 'var(--tc-err)';
 			});
 		}
 
@@ -3193,7 +2868,7 @@ return view.extend({
 		}
 
 		callVersion().then(function(res) {
-			var el = document.getElementById('tm-version-footer');
+			var el = document.getElementById('tc-version-footer');
 			if (el && res && res.version) {
 				el.textContent = 'trafficctl v' + res.version + ' (' + TRAFFICCTL_BUILD + ')';
 			}
@@ -3245,7 +2920,7 @@ return view.extend({
 					para(_('The router offloads established connections from the CPU to the hardware (NIC/SoC), ' +
 						  'achieving 2–3× higher throughput and lower CPU usage.')),
 					para(_('In this mode the kernel\'s conntrack, firewall, and tc are bypassed for offloaded flows:')),
-					E('ul', {'class': 'tm-offload-ul'}, [
+					E('ul', {'class': 'tc-offload-ul'}, [
 						E('li', {}, _('Speed monitoring — conntrack byte counters are not updated')),
 						E('li', {}, _('Traffic shaping (tc/HTB) — bypassed for offloaded flows')),
 						E('li', {}, _('Rate limiting — applies only to new connections')),
@@ -3277,25 +2952,25 @@ return view.extend({
 			}
 
 			var banner = E('div', {
-				'class': 'tm-offload-banner',
+				'class': 'tc-offload-banner',
 				'style': 'border:1px solid ' + border + ';background:' + bg
 			}, [
-				E('div', {'class': 'tm-offload-banner__row'}, [
-					E('span', {'class': 'tm-offload-banner__icon'}, icon),
-					E('div', {'class': 'tm-offload-banner__body'}, body),
+				E('div', {'class': 'tc-offload-banner__row'}, [
+					E('span', {'class': 'tc-offload-banner__icon'}, icon),
+					E('div', {'class': 'tc-offload-banner__body'}, body),
 					E('span', {
-						'class': 'tm-offload-banner__close',
+						'class': 'tc-offload-banner__close',
 						'title': _('Dismiss')
 					}, '×')
 				])
 			]);
 			banner.firstChild.lastChild.addEventListener('click', function() {
-				banner.classList.add('tm-hidden');
+				banner.classList.add('tc-hidden');
 			});
 			return banner;
 		};
 
-		var offloadBanner = E('div', {'id': 'tm-offload-banner', 'class': 'tm-hidden'});
+		var offloadBanner = E('div', {'id': 'tc-offload-banner', 'class': 'tc-hidden'});
 
 		// Debug: add ?offload_debug=1 to URL to preview all banner types at once
 		if (window.location.search.indexOf('offload_debug') !== -1) {
@@ -3303,18 +2978,18 @@ return view.extend({
 				var b = mkOffloadBanner(mode);
 				if (b) offloadBanner.appendChild(b);
 			});
-			offloadBanner.classList.remove('tm-hidden');
+			offloadBanner.classList.remove('tc-hidden');
 		} else {
 			callConfigGet().then(function(cfg) {
 				var b = mkOffloadBanner(cfg && cfg.offload_mode);
 				if (!b) return;
 				offloadBanner.appendChild(b);
-				offloadBanner.classList.remove('tm-hidden');
+				offloadBanner.classList.remove('tc-hidden');
 			});
 		}
 
-		return E('div', {'class':'cbi-map', 'style':'color:var(--tm-text)'}, [
-			E('h2', {'style':'color:var(--tm-text)'}, _('Traffic Control')),
+		return E('div', {'class':'cbi-map', 'style':'color:currentColor'}, [
+			E('h2', {'style':'color:currentColor'}, _('Traffic Control')),
 			E('div', {'class':'cbi-section'}, [
 				offloadBanner,
 				E('div', {'style':'margin-bottom:10px'}, [
@@ -3329,7 +3004,7 @@ return view.extend({
 				connsDiv,
 				activityDiv
 			]),
-			E('div', {'id':'tm-version-footer','class':'tm-version-footer'},
+			E('div', {'id':'tc-version-footer','class':'tc-version-footer'},
 				'trafficctl (' + TRAFFICCTL_BUILD + ')')
 		]);
 	},

--- a/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.js
+++ b/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.js
@@ -1518,7 +1518,7 @@ return view.extend({
 						var host = (res && res.host) ? res.host : null;
 						self._rdnsCache[it.dst] = host || null;
 						Array.prototype.forEach.call(
-							connsDiv.querySelectorAll('td[data-dst="'+it.dst+'"]'),
+							connsDiv.querySelectorAll('[data-dst="'+it.dst+'"]'),
 							function(cell) {
 								if (host) { cell.textContent = host; cell.style.color = ''; }
 								else { cell.innerHTML = '<span class="tc-c-faint">—</span>'; }
@@ -1530,7 +1530,7 @@ return view.extend({
 						if (it.gen !== self._queryGen) return;
 						self._rdnsCache[it.dst] = null;
 						Array.prototype.forEach.call(
-							connsDiv.querySelectorAll('td[data-dst="'+it.dst+'"]'),
+							connsDiv.querySelectorAll('[data-dst="'+it.dst+'"]'),
 							function(cell) { cell.innerHTML = '<span class="tc-c-faint">—</span>'; }
 						);
 					});
@@ -2064,7 +2064,7 @@ return view.extend({
 					if (groupBy !== 'none') {
 						var groups = groupConnections(data.connections, groupBy);
 						tbl = buildGroupedTable(groups, self._sortCol === 'bytes' || self._sortCol === 'count' ? self._sortCol : 'bytes', self._sortDir);
-						Array.prototype.forEach.call(tbl.querySelectorAll('th'), function(th) {
+						Array.prototype.forEach.call(tbl.querySelectorAll('.th'), function(th) {
 							th.addEventListener('click', function() {
 								var col = th.getAttribute('data-col');
 								if (self._sortCol === col) {
@@ -2081,7 +2081,7 @@ return view.extend({
 							groups.length + ' ' + _('groups from') + ' ' + data.connections.length + ' ' + _('connections') + '. ' + _('Click header to sort.')));
 					} else {
 						tbl = buildTable(data.connections, self._sortCol, self._sortDir, o.rdns, self._connHiddenCols);
-						Array.prototype.forEach.call(tbl.querySelectorAll('th'), function(th) {
+						Array.prototype.forEach.call(tbl.querySelectorAll('.th'), function(th) {
 							th.addEventListener('click', function() {
 								var col = th.getAttribute('data-col');
 								if (self._sortCol === col) {
@@ -2108,7 +2108,7 @@ return view.extend({
 								if (self._rdnsCache[dst] !== undefined) {
 									var cached = self._rdnsCache[dst];
 									Array.prototype.forEach.call(
-										connsDiv.querySelectorAll('td[data-dst="'+dst+'"]'),
+										connsDiv.querySelectorAll('[data-dst="'+dst+'"]'),
 										function(cell) {
 											if (cached) { cell.textContent = cached; cell.style.color = ''; }
 											else { cell.innerHTML = '<span class="tc-c-faint">—</span>'; }
@@ -2382,7 +2382,7 @@ return view.extend({
 		var sep = function() { return E('span', {'class':'tc-sep'}); };
 		var sectionLabel = function(t) { return E('div', {'class':'tc-section-label'}, t); };
 
-		var settingsBody = E('div', {'class':'tc-settings-body'});
+		var settingsBody = E('div', {'class':'tc-settings-body tc-hidden'});
 		var settingsCollapsed = true;
 		var settingsToggle = E('div', {'class':'tc-settings-toggle'}, [E('span', {}, '▸'), E('span', {}, _('Settings'))]);
 

--- a/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.js
+++ b/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.js
@@ -2899,19 +2899,28 @@ return view.extend({
 			]);
 
 			if (mode === 'hardware-counter') {
-				bg     = 'rgba(41,128,185,0.10)';
-				border = '#2980b9';
-				icon   = '✔️';
+				bg     = 'rgba(211,84,0,0.10)';
+				border = '#d35400';
+				icon   = '⚠️';
 				body   = E('div', {}, [
-					para(bold(_('Hardware flow offloading is active — all features work.'))),
-					para([_('The router offloads packet forwarding to the hardware (NIC/SoC) for higher throughput. ' +
-						  'The flowtable '),
+					para(bold(_('Hardware flow offloading active — real-time speed monitoring unavailable.'))),
+					para([_('The flowtable '),
 						E('code', {}, 'counter'),
-						_(' flag (Linux 5.7+ / OpenWrt 22.03+ with fw4) keeps conntrack byte counts ' +
-						  'in sync — monitoring, shaping, and rate limiting all work normally.')]),
+						_(' flag should sync hardware byte counts back to conntrack, but on many ' +
+						  'platforms (e.g. Mediatek Filogic) the driver does not implement the stats ' +
+						  'callback, so conntrack counters remain frozen for active flows.')]),
+					para(bold(_('To restore speed monitoring:'))),
+					E('ul', {'class': 'tc-offload-ul'}, [
+						E('li', {}, [
+							_('Disable hardware offload (keeps software offload): '),
+							E('code', {}, 'uci set firewall.@defaults[0].flow_offloading_hw=0 && uci commit firewall && fw4 reload'),
+						]),
+						E('li', {}, _('Or disable all flow offload in LuCI → Network → Firewall → General Settings.')),
+					]),
+					para(_('Blocking, rate limiting, and traffic shaping continue to work regardless.')),
 					docLinks,
 				]);
-			} else if (mode === 'hardware') {
+				} else if (mode === 'hardware') {
 				bg     = 'rgba(211,84,0,0.10)';
 				border = '#d35400';
 				icon   = '⚠️';

--- a/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.js
+++ b/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.js
@@ -119,11 +119,6 @@ var callShapeStats = rpc.declare({
 	expect: { result: [] }
 });
 
-var callRdns = rpc.declare({
-	object: 'luci.trafficctl',
-	method: 'rdns',
-	params: ['ip']
-});
 
 var callTelegramGet = rpc.declare({
 	object: 'luci.trafficctl',
@@ -166,16 +161,17 @@ var callVersion = rpc.declare({
 	method: 'version'
 });
 
-var callOffloadGet = rpc.declare({
+var callConfigSet = rpc.declare({
 	object: 'luci.trafficctl',
-	method: 'offload_get',
-	expect: {}
+	method: 'config_set',
+	params: ['enabled', 'default_mode', 'sw', 'hw']
 });
 
-var callOffloadSet = rpc.declare({
-	object: 'luci.trafficctl',
-	method: 'offload_set',
-	params: ['sw', 'hw']
+var callNetworkRrdnsLookup = rpc.declare({
+	object: 'network.rrdns',
+	method: 'lookup',
+	params: ['addrs', 'timeout', 'limit'],
+	expect: { '': {} }
 });
 
 var callConfigGet = rpc.declare({
@@ -1472,6 +1468,7 @@ return view.extend({
 		});
 
 		var extStatsDiv = E('div', { 'class': opts.extendedStats ? '' : 'tc-hidden' });
+		var deviceGraphDiv = E('div', { 'class': 'tc-device-graph tc-hidden' });
 		var activityDiv = E('div', { 'class': opts.showActivity ? '' : 'tc-hidden' });
 
 		var refreshPick = mkChipPick([
@@ -1514,41 +1511,32 @@ return view.extend({
 		var statsDiv  = E('div', { 'style': 'margin:8px 0', 'class': opts.showStats === false ? 'tc-hidden' : '' });
 		var connsDiv  = E('div', { 'class': opts.showConns === false ? 'tc-hidden' : '' });
 
-		var _rdnsQueue   = [];
-		var _rdnsFlying  = 0;
-		var _rdnsMax     = 4;
-		var _rdnsDispatch = function() {
-			while (_rdnsFlying < _rdnsMax && _rdnsQueue.length > 0) {
-				var item = _rdnsQueue.shift();
-				if (item.gen !== self._queryGen) continue;
-				(function(it) {
-					_rdnsFlying++;
-					callRdns(it.dst).then(function(res) {
-						_rdnsFlying--;
-						_rdnsDispatch();
-						if (it.gen !== self._queryGen) return;
-						var host = (res && res.host) ? res.host : null;
-						self._rdnsCache[it.dst] = host || null;
-						Array.prototype.forEach.call(
-							connsDiv.querySelectorAll('[data-dst="'+it.dst+'"]'),
-							function(cell) {
-								if (host) { cell.textContent = host; cell.style.color = ''; }
-								else { cell.innerHTML = '<span class="tc-c-faint">—</span>'; }
-							}
-						);
-					}).catch(function() {
-						_rdnsFlying--;
-						_rdnsDispatch();
-						if (it.gen !== self._queryGen) return;
-						self._rdnsCache[it.dst] = null;
-						Array.prototype.forEach.call(
-							connsDiv.querySelectorAll('[data-dst="'+it.dst+'"]'),
-							function(cell) { cell.innerHTML = '<span class="tc-c-faint">—</span>'; }
-						);
-					});
-				})(item);
-			}
-		};
+		function _rdnsBatch(addrs, gen) {
+			if (!addrs.length) return;
+			callNetworkRrdnsLookup(addrs, 5000, addrs.length).then(function(replies) {
+				if (gen !== self._queryGen) return;
+				addrs.forEach(function(dst) {
+					var host = (replies && replies[dst]) || null;
+					self._rdnsCache[dst] = host;
+					Array.prototype.forEach.call(
+						connsDiv.querySelectorAll('[data-dst="'+dst+'"]'),
+						function(cell) {
+							if (host) { cell.textContent = host; cell.style.color = ''; }
+							else { cell.innerHTML = '<span class="tc-c-faint">—</span>'; }
+						}
+					);
+				});
+			}).catch(function() {
+				if (gen !== self._queryGen) return;
+				addrs.forEach(function(dst) {
+					self._rdnsCache[dst] = null;
+					Array.prototype.forEach.call(
+						connsDiv.querySelectorAll('[data-dst="'+dst+'"]'),
+						function(cell) { cell.innerHTML = '<span class="tc-c-faint">—</span>'; }
+					);
+				});
+			});
+		}
 
 		// Speed graph popup on spark cell hover
 		var graphPopup = E('div', {'class':'tc-graph-popup tc-hidden'});
@@ -1993,14 +1981,32 @@ return view.extend({
 				} else {
 					updateSpeedCells();
 				}
+				updateDeviceGraph();
 			}).catch(function(){});
+		}
+
+		function updateDeviceGraph() {
+			var ip = searchSelect.getValue();
+			if (!ip || ip === '__all__') {
+				deviceGraphDiv.classList.add('tc-hidden');
+				return;
+			}
+			var hist = self._fullHistory[ip];
+			if (!hist || hist.length < 2) return;
+			var sm = self._shapeMap[ip], dm = self._dropMap[ip];
+			var lk = (sm && sm.rate_kbit > 0) ? sm.rate_kbit : ((dm && dm.rate_kbit > 0) ? dm.rate_kbit : 0);
+			var w = deviceGraphDiv.offsetWidth || 560;
+			var svg = renderFullGraph(hist, lk, w, 160);
+			if (!svg) return;
+			while (deviceGraphDiv.firstChild) deviceGraphDiv.removeChild(deviceGraphDiv.firstChild);
+			deviceGraphDiv.appendChild(svg);
+			deviceGraphDiv.classList.remove('tc-hidden');
 		}
 
 		function runSingle(ip) {
 			var o = loadOpts();
 			var proto = (o.proto && o.proto !== 'all') ? o.proto : '';
 			self._queryGen++;
-			_rdnsQueue.length = 0;
 			var gen = self._queryGen;
 
 			setStatus(statusDiv, 'loading', _('Running…'));
@@ -2110,13 +2116,11 @@ return view.extend({
 							data.connections.length + ' ' + _('connections') + '. ' + _('Click header to sort.')));
 
 						if (o.rdns) {
-							var seen = {};
+							var seen = {}, uncached = [];
 							data.connections.forEach(function(c) {
 								var dst = c.dst || '';
-								if (!dst || seen[dst]) return;
-								if (PRIVATE_RE.test(dst)) return;
+								if (!dst || seen[dst] || PRIVATE_RE.test(dst)) return;
 								seen[dst] = true;
-								// Use cached result if available
 								if (self._rdnsCache[dst] !== undefined) {
 									var cached = self._rdnsCache[dst];
 									Array.prototype.forEach.call(
@@ -2126,11 +2130,11 @@ return view.extend({
 											else { cell.innerHTML = '<span class="tc-c-faint">—</span>'; }
 										}
 									);
-									return;
+								} else {
+									uncached.push(dst);
 								}
-								_rdnsQueue.push({dst: dst, gen: gen});
-								_rdnsDispatch();
 							});
+							_rdnsBatch(uncached, gen);
 						}
 					}
 				}
@@ -2270,6 +2274,7 @@ return view.extend({
 			updateUrlParams(o);
 			updateModeUI();
 			if (ip === '__all__') {
+				deviceGraphDiv.classList.add('tc-hidden');
 				runAll();
 			} else {
 				self._stopBytesPoll();
@@ -2825,7 +2830,7 @@ return view.extend({
 			var statusSpan = E('span', {'style':'font-size:12px;color:var(--tc-muted)'}, _('Loading…'));
 			container.appendChild(statusSpan);
 
-			callOffloadGet().then(function(cfg) {
+			callConfigGet().then(function(cfg) {
 				while (container.firstChild) container.removeChild(container.firstChild);
 
 				var saveStatus = E('span', {'class':'tg-save-status'});
@@ -2837,7 +2842,7 @@ return view.extend({
 					saveTimer = setTimeout(function() {
 						saveStatus.textContent = _('Applying…');
 						saveStatus.style.color = 'var(--tc-muted)';
-						callOffloadSet(swCb.checked, hwCb.checked).then(function(res) {
+						callConfigSet(undefined, undefined, swCb.checked, hwCb.checked).then(function(res) {
 							saveStatus.textContent = (res && res.ok) ? '✓' : '✗';
 							saveStatus.style.color = (res && res.ok) ? 'var(--tc-ok)' : 'var(--tc-err)';
 						}).catch(function(e) {
@@ -3081,6 +3086,7 @@ return view.extend({
 				settingsPanel,
 				statsDiv,
 				extStatsDiv,
+				deviceGraphDiv,
 				connsDiv,
 				activityDiv
 			]),

--- a/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.js
+++ b/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.js
@@ -2843,7 +2843,7 @@ return view.extend({
 						saveStatus.textContent = _('Applying…');
 						saveStatus.style.color = 'var(--tc-muted)';
 						callConfigSet(undefined, undefined, swCb.checked, hwCb.checked).then(function(res) {
-							saveStatus.textContent = (res && res.ok) ? '✓' : '✗';
+							saveStatus.textContent = (res && res.ok) ? '✓ ' + _('Applied — firewall reloading') : '✗';
 							saveStatus.style.color = (res && res.ok) ? 'var(--tc-ok)' : 'var(--tc-err)';
 						}).catch(function(e) {
 							saveStatus.textContent = '✗';
@@ -2852,22 +2852,43 @@ return view.extend({
 					}, 400);
 				}
 
-				var swToggleEl = mkToggle('tc-offload-sw', _('Software'), cfg.sw, function() {
+				// Current mode badge
+				var modeLabels = {
+					'none':              ['⊘', _('No offload'),              'var(--tc-muted)'],
+					'software':          ['◑', _('Software offload'),        'var(--tc-speed)'],
+					'hardware-counter':  ['●', _('Hardware offload'),        'var(--tc-warn)'],
+					'hardware':          ['●', _('Hardware offload'),        'var(--tc-warn)']
+				};
+				var ml = modeLabels[cfg.offload_mode] || ['?', cfg.offload_mode, 'var(--tc-muted)'];
+				var modeBadge = E('div', {'style':'margin-bottom:10px;font-size:12px'}, [
+					E('span', {'style':'color:'+ml[2]+';font-size:15px;margin-right:4px'}, ml[0]),
+					E('span', {'style':'color:var(--tc-muted)'}, _('Current mode: ')),
+					E('b', {}, ml[1])
+				]);
+
+				// SW toggle row
+				var swToggleEl = mkToggle('tc-offload-sw', _('Software flow offload'), cfg.sw, function() {
 					hwCb.disabled = !swCb.checked;
-					if (!swCb.checked) hwCb.checked = false;
+					if (!swCb.checked) { hwCb.checked = false; }
 					doSave();
 				});
 				swCb = swToggleEl.querySelector('input');
+				var swDesc = E('div', {'class':'tc-offload-desc'},
+					_('Accelerates routing in the kernel via nftables flowtable. Speed monitoring and traffic shaping work normally.'));
 
-				var hwToggleEl = mkToggle('tc-offload-hw', _('Hardware'), cfg.hw, doSave);
+				// HW toggle row
+				var hwToggleEl = mkToggle('tc-offload-hw', _('Hardware flow offload'), cfg.hw, doSave);
 				hwCb = hwToggleEl.querySelector('input');
 				if (!cfg.sw) hwCb.disabled = true;
+				var hwDesc = E('div', {'class':'tc-offload-desc'},
+					_('Offloads routing to the hardware engine (PPE/NPU). Requires software offload. ' +
+					  '⚠ On many platforms (e.g. Mediatek Filogic) the driver does not report byte counters back to the kernel — real-time speed monitoring will show zero.'));
 
-				var note = E('div', {'style':'font-size:11px;color:var(--tc-muted);margin-top:6px'},
-					_('Hardware offload disables real-time speed monitoring on platforms that do not implement the stats callback (e.g. Mediatek Filogic). Firewall rules reload takes ~2 s after save.'));
-
-				container.appendChild(E('div', {'class':'tc-log-row'}, [swToggleEl, hwToggleEl, saveStatus]));
-				container.appendChild(note);
+				container.appendChild(modeBadge);
+				container.appendChild(E('div', {'class':'tc-offload-row'}, [swToggleEl, saveStatus]));
+				container.appendChild(swDesc);
+				container.appendChild(E('div', {'class':'tc-offload-row tc-offload-row--hw'}, [hwToggleEl]));
+				container.appendChild(hwDesc);
 			}).catch(function(e) {
 				statusSpan.textContent = '✗ ' + (e.message || e);
 				statusSpan.style.color = 'var(--tc-err)';

--- a/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.js
+++ b/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.js
@@ -597,70 +597,81 @@ function renderFullGraph(history, limitKbit, width, height) {
 	return svg;
 }
 
+function isDarkTheme() {
+	var dm = document.documentElement.getAttribute('data-darkmode');
+	if (dm === 'true') return true;
+	if (dm === 'false') return false;
+	try {
+		var bg = window.getComputedStyle(document.body).backgroundColor;
+		var m = bg.match(/rgb[a]?\((\d+)[,\s]+(\d+)[,\s]+(\d+)/);
+		if (m && (0.299 * +m[1] + 0.587 * +m[2] + 0.114 * +m[3]) < 80) return true;
+	} catch(e) {}
+	return !!(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+}
+
 function injectStyles() {
-	if (document.getElementById('tm-style')) return;
-	var s = document.createElement('style');
-	s.id = 'tm-style';
-	s.textContent =
-		':root {' +
-			'--tm-bg:        #ffffff;' +
-			'--tm-bg-alt:    #f7fafc;' +
-			'--tm-bg-subtle: #f7f8fa;' +
-			'--tm-text:      #1a202c;' +
-			'--tm-text-mute: #718096;' +
-			'--tm-text-faint:#a0aec0;' +
-			'--tm-border:    #e2e8f0;' +
-			'--tm-th-bg:     #4a5568;' +
-			'--tm-th-fg:     #ffffff;' +
-			'--tm-proto:     #2b6cb0;' +
-			'--tm-service:   #805ad5;' +
-			'--tm-state-ok:  #276749;' +
-			'--tm-state-wait:#c53030;' +
-			'--tm-state-close:#c05621;' +
-			'--tm-info-bg:   #ebf8ff;' +
-			'--tm-info-border:#90cdf4;' +
-			'--tm-info-fg:   #2c5282;' +
-			'--tm-blocked-bg:#fff5f5;' +
-			'--tm-blocked-border:#fc8181;' +
-			'--tm-blocked-fg:#c53030;' +
-			'--tm-rate-fg:   #c05621;' +
-			'--tm-drop-fg:   #9b2c2c;' +
-			'--tm-speed:     #3182ce;' +
-			'--tm-shape-fg:  #2b6cb0;' +
-			'--tm-hover:     #ebf8ff;' +
-			'--tm-section-action: #f0f4f8;' +
-			'--tm-section-data:   #ffffff;' +
-		'}' +
-		':root[data-darkmode="true"],' +
-		'html[data-darkmode="true"],' +
-		'body.dark, .dark {' +
-			'--tm-bg:        #1e1e1e;' +
-			'--tm-bg-alt:    #262626;' +
-			'--tm-bg-subtle: #242424;' +
-			'--tm-text:      #e2e8f0;' +
-			'--tm-text-mute: #a0aec0;' +
-			'--tm-text-faint:#718096;' +
-			'--tm-border:    #3a3a3a;' +
-			'--tm-th-bg:     #2d3748;' +
-			'--tm-th-fg:     #e2e8f0;' +
-			'--tm-proto:     #63b3ed;' +
-			'--tm-service:   #b794f4;' +
-			'--tm-state-ok:  #68d391;' +
-			'--tm-state-wait:#fc8181;' +
-			'--tm-state-close:#f6ad55;' +
-			'--tm-info-bg:   #1a365d;' +
-			'--tm-info-border:#2c5282;' +
-			'--tm-info-fg:   #bee3f8;' +
-			'--tm-blocked-bg:#3d1818;' +
-			'--tm-blocked-border:#9b2c2c;' +
-			'--tm-blocked-fg:#fc8181;' +
-			'--tm-rate-fg:   #f6ad55;' +
-			'--tm-drop-fg:   #fc8181;' +
-			'--tm-speed:     #63b3ed;' +
-			'--tm-shape-fg:  #63b3ed;' +
-			'--tm-hover:     #2d3748;' +
-			'--tm-section-action: #252a30;' +
-			'--tm-section-data:   #1e1e1e;' +
+	var el = document.getElementById('tm-style');
+	if (!el) { el = document.createElement('style'); el.id = 'tm-style'; document.head.appendChild(el); }
+	var D = isDarkTheme();
+	el.textContent =
+		':root{' +
+			(D ?
+				'--tm-bg:#1e1e1e;' +
+				'--tm-bg-alt:#262626;' +
+				'--tm-bg-subtle:#242424;' +
+				'--tm-text:#e2e8f0;' +
+				'--tm-text-mute:#a0aec0;' +
+				'--tm-text-faint:#718096;' +
+				'--tm-border:#3a3a3a;' +
+				'--tm-th-bg:#2d3748;' +
+				'--tm-th-fg:#e2e8f0;' +
+				'--tm-proto:#63b3ed;' +
+				'--tm-service:#b794f4;' +
+				'--tm-state-ok:#68d391;' +
+				'--tm-state-wait:#fc8181;' +
+				'--tm-state-close:#f6ad55;' +
+				'--tm-info-bg:#1a365d;' +
+				'--tm-info-border:#2c5282;' +
+				'--tm-info-fg:#bee3f8;' +
+				'--tm-blocked-bg:#3d1818;' +
+				'--tm-blocked-border:#9b2c2c;' +
+				'--tm-blocked-fg:#fc8181;' +
+				'--tm-rate-fg:#f6ad55;' +
+				'--tm-drop-fg:#fc8181;' +
+				'--tm-speed:#63b3ed;' +
+				'--tm-shape-fg:#63b3ed;' +
+				'--tm-hover:#2d3748;' +
+				'--tm-section-action:#252a30;' +
+				'--tm-section-data:#1e1e1e;'
+			:
+				'--tm-bg:#ffffff;' +
+				'--tm-bg-alt:#f7fafc;' +
+				'--tm-bg-subtle:#f7f8fa;' +
+				'--tm-text:#1a202c;' +
+				'--tm-text-mute:#718096;' +
+				'--tm-text-faint:#a0aec0;' +
+				'--tm-border:#e2e8f0;' +
+				'--tm-th-bg:#4a5568;' +
+				'--tm-th-fg:#ffffff;' +
+				'--tm-proto:#2b6cb0;' +
+				'--tm-service:#805ad5;' +
+				'--tm-state-ok:#276749;' +
+				'--tm-state-wait:#c53030;' +
+				'--tm-state-close:#c05621;' +
+				'--tm-info-bg:#ebf8ff;' +
+				'--tm-info-border:#90cdf4;' +
+				'--tm-info-fg:#2c5282;' +
+				'--tm-blocked-bg:#fff5f5;' +
+				'--tm-blocked-border:#fc8181;' +
+				'--tm-blocked-fg:#c53030;' +
+				'--tm-rate-fg:#c05621;' +
+				'--tm-drop-fg:#9b2c2c;' +
+				'--tm-speed:#3182ce;' +
+				'--tm-shape-fg:#2b6cb0;' +
+				'--tm-hover:#ebf8ff;' +
+				'--tm-section-action:#f0f4f8;' +
+				'--tm-section-data:#ffffff;'
+			) +
 		'}' +
 		'@keyframes tm-spin{to{transform:rotate(360deg)}}' +
 		'@keyframes tm-pulse{0%,100%{opacity:.5}50%{opacity:1}}' +
@@ -714,7 +725,18 @@ function injectStyles() {
 		'.tg-eye{cursor:pointer;font-size:14px;user-select:none;line-height:1}' +
 		'.tg-template-hint{font-size:10px;color:var(--tm-text-faint);margin-top:2px}' +
 		'.tg-save-status{font-size:11px;margin-left:8px;transition:opacity .3s}';
-	document.head.appendChild(s);
+}
+
+function watchTheme() {
+	var obs = new MutationObserver(injectStyles);
+	obs.observe(document.documentElement, {attributes: true, attributeFilter: ['data-darkmode']});
+	if (window.matchMedia) {
+		try {
+			window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', injectStyles);
+		} catch(e) {
+			window.matchMedia('(prefers-color-scheme: dark)').addListener(injectStyles);
+		}
+	}
 }
 
 
@@ -1565,6 +1587,7 @@ return view.extend({
 		opts = applyUrlParams(opts);
 		saveOpts(opts);
 		injectStyles();
+		watchTheme();
 
 		var devices = [];
 		(leasesRaw || '').split('\n').forEach(function(line) {

--- a/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.js
+++ b/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.js
@@ -166,6 +166,18 @@ var callVersion = rpc.declare({
 	method: 'version'
 });
 
+var callOffloadGet = rpc.declare({
+	object: 'luci.trafficctl',
+	method: 'offload_get',
+	expect: {}
+});
+
+var callOffloadSet = rpc.declare({
+	object: 'luci.trafficctl',
+	method: 'offload_set',
+	params: ['sw', 'hw']
+});
+
 var callConfigGet = rpc.declare({
 	object: 'luci.trafficctl',
 	method: 'config_get'
@@ -2798,6 +2810,65 @@ return view.extend({
 			});
 		}
 		settingsBody.appendChild(loggingSection.el);
+
+		// ── Flow Offload section (lazy-loaded) ─────────────────────────────
+		var offloadSection = mkCollapsible(_('Flow Offload'), null, false);
+		var offloadLoaded = false;
+		offloadSection.label.addEventListener('click', function() {
+			if (!offloadLoaded && !offloadSection.body.classList.contains('tc-hidden')) {
+				offloadLoaded = true;
+				loadOffloadUI(offloadSection.body);
+			}
+		});
+
+		function loadOffloadUI(container) {
+			var statusSpan = E('span', {'style':'font-size:12px;color:var(--tc-muted)'}, _('Loading…'));
+			container.appendChild(statusSpan);
+
+			callOffloadGet().then(function(cfg) {
+				while (container.firstChild) container.removeChild(container.firstChild);
+
+				var saveStatus = E('span', {'class':'tg-save-status'});
+				var saveTimer = null;
+				var swCb, hwCb;
+
+				function doSave() {
+					if (saveTimer) clearTimeout(saveTimer);
+					saveTimer = setTimeout(function() {
+						saveStatus.textContent = _('Applying…');
+						saveStatus.style.color = 'var(--tc-muted)';
+						callOffloadSet(swCb.checked, hwCb.checked).then(function(res) {
+							saveStatus.textContent = (res && res.ok) ? '✓' : '✗';
+							saveStatus.style.color = (res && res.ok) ? 'var(--tc-ok)' : 'var(--tc-err)';
+						}).catch(function(e) {
+							saveStatus.textContent = '✗';
+							saveStatus.style.color = 'var(--tc-err)';
+						});
+					}, 400);
+				}
+
+				var swToggleEl = mkToggle('tc-offload-sw', _('Software'), cfg.sw, function() {
+					hwCb.disabled = !swCb.checked;
+					if (!swCb.checked) hwCb.checked = false;
+					doSave();
+				});
+				swCb = swToggleEl.querySelector('input');
+
+				var hwToggleEl = mkToggle('tc-offload-hw', _('Hardware'), cfg.hw, doSave);
+				hwCb = hwToggleEl.querySelector('input');
+				if (!cfg.sw) hwCb.disabled = true;
+
+				var note = E('div', {'style':'font-size:11px;color:var(--tc-muted);margin-top:6px'},
+					_('Hardware offload disables real-time speed monitoring on platforms that do not implement the stats callback (e.g. Mediatek Filogic). Firewall rules reload takes ~2 s after save.'));
+
+				container.appendChild(E('div', {'class':'tc-log-row'}, [swToggleEl, hwToggleEl, saveStatus]));
+				container.appendChild(note);
+			}).catch(function(e) {
+				statusSpan.textContent = '✗ ' + (e.message || e);
+				statusSpan.style.color = 'var(--tc-err)';
+			});
+		}
+		settingsBody.appendChild(offloadSection.el);
 
 		var connFiltersRow = E('div', {'class':'tc-conn-filters-row'}, [
 			E('span', {'data-tip':_('Filter connections by protocol')}, [mkLabel(_('Proto')+':'), protoPick.el]),

--- a/luci-app-trafficctl/root/usr/libexec/rpcd/luci.trafficctl
+++ b/luci-app-trafficctl/root/usr/libexec/rpcd/luci.trafficctl
@@ -49,6 +49,8 @@ list)
 	printf '"logging_config_get":{},'
 	printf '"logging_config_set":{"enabled":"bool","log_file":"str","max_lines":"int","syslog":"bool","log_blocks":"bool","log_ratelimits":"bool","log_shapes":"bool","log_telegram":"bool","log_config":"bool"},'
 	printf '"activity_log":{"lines":"int"},'
+	printf '"offload_get":{},'
+	printf '"offload_set":{"sw":"bool","hw":"bool"},'
 	printf '"version":{}'
 	printf '}'
 	;;
@@ -334,6 +336,25 @@ call)
 		else
 			echo '{"ok":true,"lines":[]}'
 		fi
+		;;
+	offload_get)
+		sw=$(uci -q get firewall.@defaults[0].flow_offloading)
+		hw=$(uci -q get firewall.@defaults[0].flow_offloading_hw)
+		mode=$(tctl_get_offload_mode)
+		printf '{"sw":%s,"hw":%s,"mode":"%s"}' \
+			"$([ "$sw" = "1" ] && echo true || echo false)" \
+			"$([ "$hw" = "1" ] && echo true || echo false)" \
+			"$mode"
+		;;
+	offload_set)
+		read -r input
+		sw=$(echo "$input" | jsonfilter -e '@.sw' 2>/dev/null)
+		hw=$(echo "$input" | jsonfilter -e '@.hw' 2>/dev/null)
+		[ -n "$sw" ] && uci set "firewall.@defaults[0].flow_offloading=$([ "$sw" = "true" ] && echo 1 || echo 0)"
+		[ -n "$hw" ] && uci set "firewall.@defaults[0].flow_offloading_hw=$([ "$hw" = "true" ] && echo 1 || echo 0)"
+		uci commit firewall
+		/etc/init.d/firewall reload >/dev/null 2>&1 &
+		echo '{"ok":true}'
 		;;
 	version)
 		ver=$(opkg info luci-app-trafficctl 2>/dev/null | awk '/^Version:/{print $2}')

--- a/luci-app-trafficctl/root/usr/libexec/rpcd/luci.trafficctl
+++ b/luci-app-trafficctl/root/usr/libexec/rpcd/luci.trafficctl
@@ -42,15 +42,13 @@ list)
 	printf '"shape_stats":{},'
 	printf '"rdns":{"ip":"str"},'
 	printf '"config_get":{},'
-	printf '"config_set":{"enabled":"bool","default_mode":"str"},'
+	printf '"config_set":{"enabled":"bool","default_mode":"str","sw":"bool","hw":"bool"},'
 	printf '"telegram_config_get":{},'
 	printf '"telegram_config_set":{"enabled":"bool","bot_token":"str","chat_id":"str","poll_interval":"int","notify_new_device":"bool","notify_known_device":"bool","control_enabled":"bool","notify_template":"str","btn_block_inet":"bool","btn_block_wifi":"bool","btn_limiter":"bool","btn_shaper":"bool"},'
 	printf '"telegram_test":{"bot_token":"str","chat_id":"str","message":"str"},'
 	printf '"logging_config_get":{},'
 	printf '"logging_config_set":{"enabled":"bool","log_file":"str","max_lines":"int","syslog":"bool","log_blocks":"bool","log_ratelimits":"bool","log_shapes":"bool","log_telegram":"bool","log_config":"bool"},'
 	printf '"activity_log":{"lines":"int"},'
-	printf '"offload_get":{},'
-	printf '"offload_set":{"sw":"bool","hw":"bool"},'
 	printf '"version":{}'
 	printf '}'
 	;;
@@ -181,18 +179,30 @@ call)
 		enabled=$(uci -q get trafficctl.main.enabled)
 		mode=$(uci -q get trafficctl.main.default_mode)
 		offload=$(tctl_get_offload_mode)
-		printf '{"enabled":%s,"default_mode":"%s","offload_mode":"%s"}' \
+		sw=$(uci -q get firewall.@defaults[0].flow_offloading)
+		hw=$(uci -q get firewall.@defaults[0].flow_offloading_hw)
+		printf '{"enabled":%s,"default_mode":"%s","offload_mode":"%s","sw":%s,"hw":%s}' \
 			"$([ "$enabled" = "1" ] && echo true || echo false)" \
 			"${mode:-limiter}" \
-			"$offload"
+			"$offload" \
+			"$([ "$sw" = "1" ] && echo true || echo false)" \
+			"$([ "$hw" = "1" ] && echo true || echo false)"
 		;;
 	config_set)
 		read -r input
 		enabled=$(echo "$input" | jsonfilter -e '@.enabled' 2>/dev/null)
 		mode=$(echo "$input" | jsonfilter -e '@.default_mode' 2>/dev/null)
+		sw=$(echo "$input" | jsonfilter -e '@.sw' 2>/dev/null)
+		hw=$(echo "$input" | jsonfilter -e '@.hw' 2>/dev/null)
 		[ -n "$enabled" ] && uci set trafficctl.main.enabled="$([ "$enabled" = "true" ] && echo 1 || echo 0)"
 		[ -n "$mode" ] && uci set trafficctl.main.default_mode="$mode"
 		uci commit trafficctl
+		if [ -n "$sw" ] || [ -n "$hw" ]; then
+			[ -n "$sw" ] && uci set "firewall.@defaults[0].flow_offloading=$([ "$sw" = "true" ] && echo 1 || echo 0)"
+			[ -n "$hw" ] && uci set "firewall.@defaults[0].flow_offloading_hw=$([ "$hw" = "true" ] && echo 1 || echo 0)"
+			uci commit firewall
+			/etc/init.d/firewall reload >/dev/null 2>&1 &
+		fi
 		echo '{"ok":true}'
 		;;
 	telegram_config_get)
@@ -336,25 +346,6 @@ call)
 		else
 			echo '{"ok":true,"lines":[]}'
 		fi
-		;;
-	offload_get)
-		sw=$(uci -q get firewall.@defaults[0].flow_offloading)
-		hw=$(uci -q get firewall.@defaults[0].flow_offloading_hw)
-		mode=$(tctl_get_offload_mode)
-		printf '{"sw":%s,"hw":%s,"mode":"%s"}' \
-			"$([ "$sw" = "1" ] && echo true || echo false)" \
-			"$([ "$hw" = "1" ] && echo true || echo false)" \
-			"$mode"
-		;;
-	offload_set)
-		read -r input
-		sw=$(echo "$input" | jsonfilter -e '@.sw' 2>/dev/null)
-		hw=$(echo "$input" | jsonfilter -e '@.hw' 2>/dev/null)
-		[ -n "$sw" ] && uci set "firewall.@defaults[0].flow_offloading=$([ "$sw" = "true" ] && echo 1 || echo 0)"
-		[ -n "$hw" ] && uci set "firewall.@defaults[0].flow_offloading_hw=$([ "$hw" = "true" ] && echo 1 || echo 0)"
-		uci commit firewall
-		/etc/init.d/firewall reload >/dev/null 2>&1 &
-		echo '{"ok":true}'
 		;;
 	version)
 		ver=$(opkg info luci-app-trafficctl 2>/dev/null | awk '/^Version:/{print $2}')

--- a/luci-app-trafficctl/root/usr/local/bin/trafficctl-bytes.sh
+++ b/luci-app-trafficctl/root/usr/local/bin/trafficctl-bytes.sh
@@ -5,7 +5,12 @@
 
 . /usr/local/bin/trafficctl-fw.sh
 
-[ "$(tctl_get_offload_mode)" = "software" ] && [ "$TCTL_FW" = "nft" ] && exec /usr/local/bin/trafficctl-bytes-nft.sh
+# Any offload mode (software, hardware, hardware-counter) bypasses conntrack counters
+# for fast-path packets. Use nftables counters at forward priority -200 (before the
+# flowtable at -150) which capture every packet regardless of offload state.
+# Only pure "none" mode has accurate conntrack counters.
+_offload=$(tctl_get_offload_mode)
+[ "$_offload" != "none" ] && [ "$TCTL_FW" = "nft" ] && exec /usr/local/bin/trafficctl-bytes-nft.sh
 
 LAN_DEV=$(tctl_get_lan_device)
 LAN_SUBNET=$(ip -4 addr show dev "$LAN_DEV" 2>/dev/null | grep -oE 'inet [0-9.]+' | head -1 | awk '{print $2}')

--- a/luci-app-trafficctl/root/usr/local/bin/trafficctl-device.sh
+++ b/luci-app-trafficctl/root/usr/local/bin/trafficctl-device.sh
@@ -282,23 +282,45 @@ BEGIN { n=0 }
 ')
 
 # Optionally resolve DNS for connection destinations
-if [ "$DO_RDNS" = "1" ] && command -v dig >/dev/null 2>&1; then
+if [ "$DO_RDNS" = "1" ]; then
     DST_IPS=$(echo "$CONNTRACK_DATA" | grep -oE 'dst=[0-9.]+' | sed 's/dst=//' | sort -u | grep -v "^$IP$")
-    RDNS_MAP="/tmp/trafficctl_rdns_$$"
-    : > "$RDNS_MAP"
-    for dip in $DST_IPS; do
-        host=$(dig +short +time=1 +tries=1 -x "$dip" 2>/dev/null | grep -v '^;;' | head -1 | sed 's/\.$//')
-        case "$host" in
-            *[!a-zA-Z0-9._-]*|"") continue ;;
-        esac
-        echo "$dip $host" >> "$RDNS_MAP"
-    done
-    if [ -s "$RDNS_MAP" ]; then
-        # Build sed expression from map
-        SED_EXPR=$(awk '{printf "s|\"dst\":\"%s\",\"host\":\"\"|\"dst\":\"%s\",\"host\":\"%s\"|g\n", $1, $1, $2}' "$RDNS_MAP")
-        CONNS_OUT=$(printf "%s" "$CONNS_OUT" | sed "$SED_EXPR")
+    if [ -n "$DST_IPS" ]; then
+        RDNS_MAP="/tmp/trafficctl_rdns_$$"
+        : > "$RDNS_MAP"
+        RDNS_DONE=0
+        # Batch resolve via ubus network.rrdns (same as LuCI frontend; no extra packages needed)
+        if command -v ubus >/dev/null 2>&1; then
+            ADDRS_JSON=$(echo "$DST_IPS" | awk '{printf "%s\"%s\"", (NR>1?",":""), $1}')
+            RDNS_RESULT=$(ubus call network.rrdns lookup \
+                "{\"addrs\":[$ADDRS_JSON],\"timeout\":3000,\"limit\":64}" 2>/dev/null)
+            if [ -n "$RDNS_RESULT" ]; then
+                RDNS_DONE=1
+                for dip in $DST_IPS; do
+                    host=$(printf '%s' "$RDNS_RESULT" | jsonfilter -e "@[\"$dip\"]" 2>/dev/null)
+                    case "$host" in
+                        *[!a-zA-Z0-9._-]*|"") continue ;;
+                    esac
+                    echo "$dip $host" >> "$RDNS_MAP"
+                done
+            fi
+        fi
+        # Fallback: per-IP nslookup (BusyBox, always available on OpenWrt)
+        if [ "$RDNS_DONE" = "0" ] && command -v nslookup >/dev/null 2>&1; then
+            for dip in $DST_IPS; do
+                host=$(nslookup "$dip" 2>/dev/null | sed -n 's/.*name = \(.*\)\.$/\1/p' | head -1)
+                case "$host" in
+                    *[!a-zA-Z0-9._-]*|"") continue ;;
+                esac
+                echo "$dip $host" >> "$RDNS_MAP"
+            done
+        fi
+        if [ -s "$RDNS_MAP" ]; then
+            # Build sed expression from map
+            SED_EXPR=$(awk '{printf "s|\"dst\":\"%s\",\"host\":\"\"|\"dst\":\"%s\",\"host\":\"%s\"|g\n", $1, $1, $2}' "$RDNS_MAP")
+            CONNS_OUT=$(printf "%s" "$CONNS_OUT" | sed "$SED_EXPR")
+        fi
+        rm -f "$RDNS_MAP"
     fi
-    rm -f "$RDNS_MAP"
 fi
 
 # Output final JSON

--- a/luci-app-trafficctl/root/usr/local/bin/trafficctl-rdns.sh
+++ b/luci-app-trafficctl/root/usr/local/bin/trafficctl-rdns.sh
@@ -19,10 +19,15 @@ if ! tctl_validate_ip "$IP"; then
 fi
 
 HOST=""
-if command -v dig >/dev/null 2>&1; then
-    HOST=$(dig -4 +short +time=1 +tries=1 -x "$IP" 2>/dev/null | grep -v '^;;' | head -1 | sed 's/\.$//')
-elif command -v nslookup >/dev/null 2>&1; then
-    HOST=$(nslookup "$IP" 2>/dev/null | grep 'name =' | awk '{print $NF}' | sed 's/\.$//')
+# Try ubus network.rrdns (same resolver the LuCI frontend uses; always available via rpcd)
+if command -v ubus >/dev/null 2>&1; then
+    HOST=$(ubus call network.rrdns lookup \
+        "{\"addrs\":[\"$IP\"],\"timeout\":2000,\"limit\":1}" 2>/dev/null \
+        | jsonfilter -e "@[\"$IP\"]" 2>/dev/null)
+fi
+# Fallback: BusyBox nslookup (always available on OpenWrt)
+if [ -z "$HOST" ] && command -v nslookup >/dev/null 2>&1; then
+    HOST=$(nslookup "$IP" 2>/dev/null | sed -n 's/.*name = \(.*\)\.$/\1/p' | head -1)
 fi
 
 # Validate hostname (only allow safe chars)

--- a/luci-app-trafficctl/root/usr/share/rpcd/acl.d/luci-app-trafficctl.json
+++ b/luci-app-trafficctl/root/usr/share/rpcd/acl.d/luci-app-trafficctl.json
@@ -25,7 +25,8 @@
 					"ratelimit", "shape_add", "shape_remove", "shape_status",
 					"config_set",
 					"telegram_config_set", "telegram_test",
-					"logging_config_set"
+					"logging_config_set",
+					"config_set"
 				]
 			},
 			"uci": [ "trafficctl" ]


### PR DESCRIPTION
## Summary

- **LuCI native tables** — all `<table>`/`<tr>`/`<td>` replaced with `div.table > div.tr > div.td`; CSS system renamed from `--tm-*` to `--tc-*`; dead helper functions removed; emoji reduced to two (⏸ blocked, ⚡ limiter)
- **Dark mode** — three-tier detection (Bootstrap `data-darkmode` → computed body luminance for Argon → OS `prefers-color-scheme`); live theme switching via MutationObserver without page reload
- **Hardware flow offload fix** — on Mediatek PPE the `flow_offload_stats` callback is not implemented, so conntrack counters are frozen for active flows; speed monitoring was showing near-zero values. Routing all offload modes through the nft counter path and returning `[]` (instead of misleading frozen values) for HW-offloaded flows
- **SW/HW offload toggles** — new collapsible section in settings with mode badge (⊘ / ◑ / ●), per-toggle descriptions, and ⚠ warning for HW offload; changes take effect immediately via `fw4 reload`
- **Batch rDNS** — replaced 4-at-a-time sequential `network.rrdns.lookup` queue with single batch call for all uncached IPs; fixes "resolving…" stuck state
- **Per-device speed graph** — inline sparkline shown in extended stats panel when a single device is selected, updated on every bytes poll
- **bind-dig removed** — `trafficctl-rdns.sh` and `trafficctl-device.sh` now use `ubus call network.rrdns lookup` + BusyBox `nslookup` fallback; no extra packages required
- **Build fixes** — `--format ustar` in `build-ipk.sh` prevents macOS PaxHeader corruption on BusyBox tar

## Test plan

- [ ] ShellCheck passes on all shell scripts
- [ ] ESLint passes on JS
- [ ] OpenWrt compat matrix (48 versions × 4 arches) green
- [ ] LuCI page loads on 22.03 and 23.05 with Bootstrap and Argon themes
- [ ] Dark mode detects correctly on Argon without page reload
- [ ] Offload badge shows correct mode; SW/HW toggles apply via `fw4 reload`
- [ ] rDNS resolves without getting stuck
- [ ] Per-device speed graph appears when selecting a single device

🤖 Generated with [Claude Code](https://claude.com/claude-code)