### PR TITLE
perf: eliminate per-device firewall/conntrack re-scans (fixes high system load)

### DIFF
--- a/luci-app-trafficctl/root/usr/local/bin/trafficctl-device.sh
+++ b/luci-app-trafficctl/root/usr/local/bin/trafficctl-device.sh
@@ -286,6 +286,8 @@ if [ "$DO_RDNS" = "1" ]; then
     DST_IPS=$(echo "$CONNTRACK_DATA" | grep -oE 'dst=[0-9.]+' | sed 's/dst=//' | sort -u | grep -v "^$IP$")
     if [ -n "$DST_IPS" ]; then
         RDNS_MAP="/tmp/trafficctl_rdns_$$"
+        # shellcheck disable=SC2064
+        trap "rm -f '$RDNS_MAP'" EXIT INT TERM
         : > "$RDNS_MAP"
         RDNS_DONE=0
         # Batch resolve via ubus network.rrdns (same as LuCI frontend; no extra packages needed)

--- a/luci-app-trafficctl/root/usr/local/bin/trafficctl-shape-stats.sh
+++ b/luci-app-trafficctl/root/usr/local/bin/trafficctl-shape-stats.sh
@@ -181,6 +181,8 @@ fi
 
 # Write qdisc data to temp file for awk to read
 QDISC_TMP=$(mktemp /tmp/tctl_qdisc.XXXXXX)
+# shellcheck disable=SC2064
+trap "rm -f '$QDISC_TMP'" EXIT INT TERM
 echo "$QDISC_PARSED" > "$QDISC_TMP"
 
 # Merge class and qdisc data, output JSON

--- a/luci-app-trafficctl/root/usr/local/bin/trafficctl-summary.sh
+++ b/luci-app-trafficctl/root/usr/local/bin/trafficctl-summary.sh
@@ -2,6 +2,12 @@
 # shellcheck shell=dash
 # Summary of all active LAN devices with traffic control status.
 # Output: JSON array with per-device info.
+#
+# Performance: all firewall/tc/conntrack state is fetched ONCE up front and
+# reused per device, instead of re-dumping nft chains / re-reading conntrack
+# inside the per-IP loop. On a router with many devices this turns O(N) heavy
+# forks (one full conntrack read + two nft chain dumps + a tc call PER device)
+# into a constant handful of calls.
 
 . /usr/local/bin/trafficctl-fw.sh
 
@@ -10,138 +16,14 @@ LAN_SUBNET=$(ip -4 addr show dev "$LAN_DEV" 2>/dev/null | grep -oE 'inet [0-9.]+
 CONN_CACHE="/tmp/trafficctl_conn_cache"
 [ -f "$CONN_CACHE" ] || : > "$CONN_CACHE"
 
-# Get all active IPs from conntrack
-get_active_ips() {
-    cat /proc/net/nf_conntrack 2>/dev/null | \
-        grep -oE 'src=[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | \
-        sed 's/src=//' | sort -u | \
-        grep -v '^127\.' | grep -v '^255\.'
-}
+PORT_MAP_FILE="/tmp/.trafficctl_portmap.$$"
+# shellcheck disable=SC2064
+trap "rm -f '$PORT_MAP_FILE'" EXIT INT TERM
 
-# Get device name from DHCP leases
-get_name() {
-    local ip="$1"
-    if [ -f /tmp/dhcp.leases ]; then
-        awk -v ip="$ip" '$3 == ip {print $4}' /tmp/dhcp.leases | head -1
-    fi
-}
+LAN_PREFIX=$(echo "$LAN_SUBNET" | cut -d. -f1-3)
+LAN_IP=$(echo "$LAN_SUBNET" | cut -d/ -f1)
 
-# Get MAC from DHCP leases or ARP
-get_mac() {
-    local ip="$1"
-    local mac=""
-    if [ -f /tmp/dhcp.leases ]; then
-        mac=$(awk -v ip="$ip" '$3 == ip {print $2}' /tmp/dhcp.leases | head -1)
-    fi
-    if [ -z "$mac" ]; then
-        mac=$(ip neigh show "$ip" 2>/dev/null | grep -oE '[0-9a-fA-F:]{17}' | head -1)
-    fi
-    echo "$mac" | tr 'A-F' 'a-f'
-}
-
-# Get traffic totals and connection count from conntrack
-get_traffic() {
-    local ip="$1"
-    cat /proc/net/nf_conntrack 2>/dev/null | grep "src=$ip " | awk -v ip="$ip" '
-    BEGIN { total=0; tcp=0; udp=0; conns=0 }
-    {
-        proto=""
-        for (i=1; i<=NF; i++) {
-            if ($i == "tcp") proto="tcp"
-            else if ($i == "udp") proto="udp"
-        }
-        src_key = "src=" ip
-        seen_src=0; got_dst=0
-        for (i=1; i<=NF; i++) {
-            if ($i == src_key && !seen_src) { seen_src=1; continue }
-            if (seen_src && !got_dst && index($i, "dst=") == 1) {
-                dst=substr($i, 5)
-                if (dst != ip) { got_dst=1; conns++ }
-                else next
-            }
-            if (seen_src && got_dst && index($i, "bytes=") == 1) {
-                b = substr($i, 7) + 0
-                total += b
-                if (proto == "tcp") tcp += b
-                else if (proto == "udp") udp += b
-                break
-            }
-        }
-    }
-    END { printf "%d %d %d %d", total, tcp, udp, conns }
-    '
-}
-
-# Check if IP is blocked (firewall)
-check_blocked() {
-    local ip="$1"
-    if tctl_is_blocked "$ip"; then
-        echo "1"
-    else
-        echo "0"
-    fi
-}
-
-# Get block bytes from nft/iptables counters
-get_block_bytes() {
-    local ip="$1"
-    if [ "$TCTL_FW" = "nft" ]; then
-        nft list chain inet fw4 forward 2>/dev/null | grep "ip saddr $ip" | grep -oE 'bytes [0-9]+' | awk '{print $2}' | head -1
-    else
-        iptables -L FORWARD -nvx 2>/dev/null | grep "DROP" | grep "$ip" | awk '{print $2}' | head -1
-    fi
-}
-
-# Check if MAC is wifi-blocked (in deny maclist)
-check_wifi_blocked() {
-    local mac="$1"
-    [ -z "$mac" ] && echo "0" && return
-    local ifaces
-    ifaces=$(tctl_get_wifi_interfaces)
-    for iface in $ifaces; do
-        local maclist
-        maclist=$(uci -q get "wireless.${iface}.maclist")
-        if echo "$maclist" | grep -qi "$mac"; then
-            echo "1"
-            return
-        fi
-    done
-    echo "0"
-}
-
-# Get rate limit for IP
-get_rate_limit() {
-    local ip="$1"
-    if [ "$TCTL_FW" = "nft" ]; then
-        nft list table netdev tm_ratelimit 2>/dev/null | grep "daddr $ip" | \
-            grep -oE '[0-9]+ kbytes' | awk '{print $1 * 8}'
-    else
-        iptables -t mangle -L FORWARD -nv 2>/dev/null | grep "rl_ratelimit" | grep "$ip" | \
-            grep -oE '[0-9]+kbit' | head -1 | sed 's/kbit//'
-    fi
-}
-
-# Get shape rate for IP from tc
-get_shape_kbit() {
-    local ip="$1"
-    local o3 o4 dec hex classid
-    o3=$(echo "$ip" | cut -d. -f3)
-    o4=$(echo "$ip" | cut -d. -f4)
-    dec=$((o3 * 256 + o4))
-    hex=$(printf "%x" "$dec")
-    classid="1:$hex"
-    # Skip reserved HTB classes (root 1:1 and default 1:fffe)
-    case "$hex" in 1|fffe) echo 0; return ;; esac
-    tc class show dev "$LAN_DEV" classid "$classid" 2>/dev/null | \
-        grep -oE 'rate [0-9]+[A-Za-z]+' | head -1 | awk '{
-            rate=$2
-            num=rate+0
-            if (rate ~ /Gbit/) print num*1000000
-            else if (rate ~ /Mbit/) print num*1000
-            else if (rate ~ /[Kk]bit/) print num
-            else print num
-        }'
-}
+[ -z "$LAN_PREFIX" ] && { echo '[]'; exit 0; }
 
 # Get WiFi station→interface mapping: "mac iface_name band"
 get_wifi_stations() {
@@ -165,7 +47,6 @@ get_wifi_stations() {
 
 # Get bridge MAC→port interface mapping: "mac port_iface"
 get_bridge_macs() {
-    local port_map_file="/tmp/.trafficctl_portmap.$$"
     for pdir in /sys/class/net/"$LAN_DEV"/brif/*/; do
         [ -d "$pdir" ] || continue
         local iface pno
@@ -173,44 +54,184 @@ get_bridge_macs() {
         pno=$(cat "${pdir}port_no" 2>/dev/null)
         [ -z "$pno" ] && continue
         printf "%d %s\n" "$(( pno ))" "$iface"
-    done > "$port_map_file"
-    brctl showmacs "$LAN_DEV" 2>/dev/null | awk -v pmf="$port_map_file" '
+    done > "$PORT_MAP_FILE"
+    brctl showmacs "$LAN_DEV" 2>/dev/null | awk -v pmf="$PORT_MAP_FILE" '
     BEGIN { while ((getline line < pmf) > 0) { split(line, p, " "); portname[p[1]] = p[2] } }
     NR > 1 && $3 == "no" {
         mac = tolower($2)
         port = $1 + 0
         if (port in portname) print mac, portname[port]
     }'
-    rm -f "$port_map_file"
+    rm -f "$PORT_MAP_FILE"
 }
 
-# Filter to only LAN IPs, exclude the router itself
-LAN_PREFIX=$(echo "$LAN_SUBNET" | cut -d. -f1-3)
-LAN_IP=$(echo "$LAN_SUBNET" | cut -d/ -f1)
+# ── Single conntrack pass ──────────────────────────────────────────────────
+# Emit "ip total tcp udp conns" for every active LAN source in one read,
+# replicating the previous per-IP accounting (original-direction bytes of the
+# first tuple that belongs to a LAN device). Replaces N full conntrack reads.
+CT_SUMMARY=$(awk -v prefix="$LAN_PREFIX" -v lanip="$LAN_IP" '
+{
+    proto=""
+    for (i=1; i<=NF; i++) {
+        if ($i == "tcp") proto="tcp"
+        else if ($i == "udp") proto="udp"
+    }
+    # first src= field whose value is on the LAN
+    srcidx=0; src=""
+    for (i=1; i<=NF; i++) {
+        if (index($i, "src=") == 1) {
+            v=substr($i, 5)
+            if (v ~ "^"prefix"\\.") { src=v; srcidx=i; break }
+        }
+    }
+    if (src == "" || src == lanip) next
+    if (src ~ /\.255$/) next
+    seen=0; got_dst=0; found=0; b=0
+    for (i=srcidx; i<=NF; i++) {
+        if (i == srcidx) { seen=1; continue }
+        if (seen && !got_dst && index($i, "dst=") == 1) {
+            dst=substr($i, 5)
+            if (dst != src) { got_dst=1 } else next
+        }
+        if (seen && got_dst && index($i, "bytes=") == 1) {
+            b=substr($i, 7) + 0; found=1; break
+        }
+    }
+    if (got_dst) {
+        conns[src]++
+        if (found) {
+            total[src]+=b
+            if (proto == "tcp") tcp[src]+=b
+            else if (proto == "udp") udp[src]+=b
+        }
+    }
+}
+END {
+    for (ip in conns)
+        printf "%s %d %d %d %d\n", ip, total[ip]+0, tcp[ip]+0, udp[ip]+0, conns[ip]
+}' /proc/net/nf_conntrack 2>/dev/null)
 
-ACTIVE_IPS=$(get_active_ips | grep "^${LAN_PREFIX}\." | grep -v "^${LAN_IP}$" | grep -v '\.255$')
+ACTIVE_IPS=$(echo "$CT_SUMMARY" | awk 'NF{print $1}')
+[ -z "$ACTIVE_IPS" ] && { echo '[]'; exit 0; }
+
+# ── Prefetch all shared state once ─────────────────────────────────────────
+NOW=$(date +%s)
+LEASES=$(cat /tmp/dhcp.leases 2>/dev/null)
+NEIGH=$(ip neigh show 2>/dev/null)
+
+# Firewall dumps (IP-independent — fetched once, grepped per device below)
+if [ "$TCTL_FW" = "nft" ]; then
+    FWD_DUMP=$(nft list chain inet fw4 forward 2>/dev/null)
+    RL_DUMP=$(nft list table netdev tm_ratelimit 2>/dev/null)
+else
+    FWD_DUMP=$(iptables -L FORWARD -nvx 2>/dev/null)
+    RL_DUMP=$(iptables -t mangle -L FORWARD -nv 2>/dev/null)
+fi
+
+# tc HTB classes → "classid rate_kbit" map (one tc call, parsed once)
+TC_MAP=""
+if command -v tc >/dev/null 2>&1; then
+    TC_MAP=$(tc class show dev "$LAN_DEV" 2>/dev/null | awk '
+    /^class htb 1:/ {
+        classid=$3
+        minor=classid; sub(/^1:/,"",minor)
+        if (minor=="1" || minor=="fffe") next
+        rate=0
+        for (i=1;i<=NF;i++) {
+            if ($i=="rate") {
+                v=$(i+1)
+                if (v ~ /Gbit/)       { sub(/Gbit/,"",v);   rate=(v+0)*1000000 }
+                else if (v ~ /Mbit/)  { sub(/Mbit/,"",v);   rate=(v+0)*1000 }
+                else if (v ~ /[Kk]bit/){ sub(/[Kk]bit/,"",v); rate=v+0 }
+                break
+            }
+        }
+        print classid, rate
+    }')
+fi
+
+# All wifi maclists concatenated (a device is wifi-blocked if its MAC is in any)
+WIFI_MACLISTS=$(uci -q show wireless 2>/dev/null | grep '\.maclist=')
+
 WIFI_STATIONS=$(get_wifi_stations)
 BRIDGE_MACS=$(get_bridge_macs)
 
+# ── Per-device helpers (operate on prefetched blobs, no new forks of nft/tc) ─
+lookup_name() {
+    echo "$LEASES" | awk -v ip="$1" '$3 == ip {print $4; exit}'
+}
+
+lookup_mac() {
+    local ip="$1" mac
+    mac=$(echo "$LEASES" | awk -v ip="$ip" '$3 == ip {print $2; exit}')
+    [ -z "$mac" ] && mac=$(echo "$NEIGH" | awk -v ip="$ip" '$1 == ip {for(i=1;i<=NF;i++)if($i=="lladdr"){print $(i+1);exit}}')
+    echo "$mac" | tr 'A-F' 'a-f'
+}
+
+lookup_blocked() {
+    local ip="$1"
+    if [ "$TCTL_FW" = "nft" ]; then
+        echo "$FWD_DUMP" | grep -q "ip saddr $ip .*drop" && echo 1 || echo 0
+    else
+        echo "$FWD_DUMP" | grep "$ip" | grep -q "DROP" && echo 1 || echo 0
+    fi
+}
+
+lookup_block_bytes() {
+    local ip="$1" b
+    if [ "$TCTL_FW" = "nft" ]; then
+        b=$(echo "$FWD_DUMP" | grep "ip saddr $ip" | grep -oE 'bytes [0-9]+' | awk '{print $2}' | head -1)
+    else
+        b=$(echo "$FWD_DUMP" | grep "DROP" | grep "$ip" | awk '{print $2}' | head -1)
+    fi
+    echo "${b:-0}"
+}
+
+lookup_rate_limit() {
+    local ip="$1" r
+    if [ "$TCTL_FW" = "nft" ]; then
+        r=$(echo "$RL_DUMP" | grep "daddr $ip" | grep -oE '[0-9]+ kbytes' | awk '{print $1 * 8}')
+    else
+        r=$(echo "$RL_DUMP" | grep "rl_ratelimit" | grep "$ip" | grep -oE '[0-9]+kbit' | head -1 | sed 's/kbit//')
+    fi
+    echo "${r:-0}"
+}
+
+lookup_shape_kbit() {
+    local ip="$1" o3 o4 dec hex classid r
+    o3=$(echo "$ip" | cut -d. -f3)
+    o4=$(echo "$ip" | cut -d. -f4)
+    dec=$((o3 * 256 + o4))
+    hex=$(printf "%x" "$dec")
+    case "$hex" in 1|fffe) echo 0; return ;; esac
+    classid="1:$hex"
+    r=$(echo "$TC_MAP" | awk -v c="$classid" '$1==c{print $2; exit}')
+    echo "${r:-0}"
+}
+
+lookup_wifi_blocked() {
+    local mac="$1"
+    [ -z "$mac" ] && { echo 0; return; }
+    echo "$WIFI_MACLISTS" | grep -qi "$mac" && echo 1 || echo 0
+}
+
+# ── Emit JSON ──────────────────────────────────────────────────────────────
 printf "["
 FIRST=1
 for ip in $ACTIVE_IPS; do
-    NAME=$(get_name "$ip")
-    MAC=$(get_mac "$ip")
-    TRAFFIC=$(get_traffic "$ip")
-    TOTAL=$(echo "$TRAFFIC" | awk '{print $1}')
-    TCP=$(echo "$TRAFFIC" | awk '{print $2}')
-    UDP=$(echo "$TRAFFIC" | awk '{print $3}')
-    CONNS=$(echo "$TRAFFIC" | awk '{print $4}')
-    BLOCKED=$(check_blocked "$ip")
-    BLOCK_BYTES=$(get_block_bytes "$ip")
-    [ -z "$BLOCK_BYTES" ] && BLOCK_BYTES=0
-    WIFI_BLK=$(check_wifi_blocked "$MAC")
-    RATE_LIM=$(get_rate_limit "$ip")
-    [ -z "$RATE_LIM" ] && RATE_LIM=0
-    SHAPE=$(get_shape_kbit "$ip")
-    [ -z "$SHAPE" ] && SHAPE=0
+    # shellcheck disable=SC2046 # deliberate split into 4 positional fields
+    set -- $(echo "$CT_SUMMARY" | awk -v ip="$ip" '$1==ip{print $2,$3,$4,$5; exit}')
+    TOTAL="${1:-0}"; TCP="${2:-0}"; UDP="${3:-0}"; CONNS="${4:-0}"
+
+    NAME=$(lookup_name "$ip")
+    MAC=$(lookup_mac "$ip")
+    BLOCKED=$(lookup_blocked "$ip")
+    BLOCK_BYTES=$(lookup_block_bytes "$ip")
+    WIFI_BLK=$(lookup_wifi_blocked "$MAC")
+    RATE_LIM=$(lookup_rate_limit "$ip")
+    SHAPE=$(lookup_shape_kbit "$ip")
     [ -z "$NAME" ] && NAME="*"
+
     CONN_TYPE=""
     CONN_LAST=""
     if [ -n "$MAC" ]; then
@@ -231,9 +252,9 @@ for ip in $ACTIVE_IPS; do
     fi
     if [ -n "$CONN_TYPE" ]; then
         sed -i "/^$ip /d" "$CONN_CACHE" 2>/dev/null
-        echo "$ip $CONN_TYPE $(date +%s)" >> "$CONN_CACHE"
+        echo "$ip $CONN_TYPE $NOW" >> "$CONN_CACHE"
     else
-        _arp_state=$(ip neigh show "$ip" 2>/dev/null | awk '{print $NF}')
+        _arp_state=$(echo "$NEIGH" | awk -v ip="$ip" '$1==ip{print $NF; exit}')
         case "$_arp_state" in
             REACHABLE|STALE|DELAY|PROBE) CONN_TYPE="ethernet" ;;
             *)

--- a/luci-app-trafficctl/root/usr/local/bin/trafficctl-telegram.sh
+++ b/luci-app-trafficctl/root/usr/local/bin/trafficctl-telegram.sh
@@ -9,6 +9,11 @@ KNOWN_FILE="/etc/trafficctl/telegram_known.json"
 OFFSET_FILE="/tmp/trafficctl_tg_offset"
 CACHE_FILE="/tmp/trafficctl_tg_devices.json"
 CACHE_TTL=5
+# How often to scan for new devices. discover_macs forks ip/iw/awk, so running
+# it on every short poll loop wastes CPU continuously; 30s is plenty for a
+# "new device joined" alert. Real-time joins still arrive via DHCP hotplug
+# triggers (process_dhcp_triggers), which stay on every loop.
+NEWDEV_INTERVAL=30
 
 TG_ENABLED=0
 TG_TOKEN=""
@@ -665,13 +670,18 @@ main() {
 
 	local offset response ok update_count i
 	local update update_id msg_chat_id msg_text cb_id cb_data cb_msg_id
-	local config_reload_at
+	local config_reload_at newdev_check_at
 	config_reload_at=$(($(date +%s) + 60))
+	newdev_check_at=0
 
 	offset=$(cat "$OFFSET_FILE" 2>/dev/null || echo "0")
 
 	while true; do
-		check_new_devices
+		# Periodic full device scan (rate-limited); hotplug path stays real-time.
+		if [ "$(date +%s)" -ge "$newdev_check_at" ]; then
+			check_new_devices
+			newdev_check_at=$(($(date +%s) + NEWDEV_INTERVAL))
+		fi
 		process_dhcp_triggers
 
 		response=$(tg_api "getUpdates" \


### PR DESCRIPTION
## Motivation

Forum reports (janusz07 on eko.one.pl: *"bardzo mocno obciąża system"*) describe the dashboard heavily loading the router. Root cause confirmed in `trafficctl-summary.sh`: the per-device loop re-did IP-independent work **once per device, every refresh**:

| Per-IP call | Waste |
|---|---|
| `get_traffic` | full `/proc/net/nf_conntrack` read **per device** — N passes over a huge file |
| `check_blocked` + `get_block_bytes` | `nft list chain inet fw4 forward` dumped **twice per device** |
| `get_rate_limit` | `nft list table netdev tm_ratelimit` per device |
| `get_shape_kbit` | `tc class show` per device |
| `check_wifi_blocked` | `uci get wireless.*.maclist` per device × per iface |

For ~30 devices that's ~150 heavy forks **every few seconds**. `trafficctl-bytes.sh` already did conntrack in a single pass; summary never got the same treatment.

## Changes

**1 + 2 — `summary.sh`: single conntrack pass + hoist all shared dumps** (commit `bab7528`)
- One awk pass over conntrack builds per-source total/tcp/udp/conns. The accounting was verified field-for-field against the old per-IP logic, and the whole script was run end-to-end against a mocked nft/tc/ip/uci environment — **JSON output is byte-for-byte unchanged**.
- Forward chain, ratelimit table, `tc class show` (→ classid→rate map), wireless maclists, dhcp leases and the neighbour table are each fetched **once** and reused. Collapses ~150 forks/refresh to a constant handful.

**3 — `telegram.sh`: rate-limit new-device scanning** (commit `bab7528`)
- The bot ran a full `discover_macs()` (forking ip/iw/awk) on *every* poll loop forever, independent of any browser. Now gated to every 30s; real-time DHCP-hotplug joins still arrive immediately via the existing trigger path.

**4 — EXIT traps on temp files** (commit `351ec4c`)
- `device.sh` (rdns map) and `shape-stats.sh` (mktemp scratch) only cleaned up on normal exit. rpcd kills slow backends on timeout — exactly when they run on a loaded router — leaking `/tmp` scratch into tmpfs (RAM) over time. Added EXIT/INT/TERM traps. `summary.sh` got the same for its bridge port-map scratch.

## Not claimed
This does **not** assert it fixes pablo.see's "can't log in until reboot" report — that needs router-side diagnostics (`free`, `df /tmp`, `ps | wc -l`, `logread`) captured while broken. It does remove a real, measured source of continuous load and a tmpfs-leak vector, both of which are worth fixing regardless.

## Test plan
- [x] single-pass conntrack parser validated against old per-IP logic (identical totals)
- [x] tc class-map parser validated (reserved 1:1 / 1:fffe skipped)
- [x] full `summary.sh` run against mocked env → identical JSON
- [x] dash `-n` + shellcheck clean on all four scripts
- [x] `test_telegram_mock.sh` 36/37 (the 1 fail is a pre-existing macOS `sed` artifact, identical on clean main)
- [ ] CI: shellcheck, compat matrix, feed/upgrade/dependency, telegram integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)