### PR TITLE
feat: multi-bridge / VLAN device discovery (closes #13)

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -117,7 +117,7 @@ In practice, both achieve the same result (excess packets are dropped), but the 
 
 1. **IPv4 only** -- The current implementation only handles IPv4 addresses. IPv6 connections are not tracked, blocked, or shaped.
 
-2. **Single LAN subnet assumption** -- The shaping class ID encoding (`third_octet * 256 + fourth_octet`) assumes all devices are on 192.168.x.x. Non-standard subnets (10.x.x.x) will work for blocking and limiting but may have class ID collisions if multiple /24s are used.
+2. **Multiple LAN subnets** -- Device discovery is multi-bridge / multi-VLAN aware: all interfaces in non-WAN firewall zones are scanned (VPN/tunnel zones such as WireGuard/AmneziaWG are excluded because they are masqueraded). The one remaining caveat is the **shaping** class ID encoding (`third_octet * 256 + fourth_octet`): two devices on different subnets that share the same last two octets (e.g. `192.168.0.5` and `10.0.0.5`) map to the same HTB class. Monitoring, blocking and rate-limiting are unaffected; only simultaneous shaping of such a colliding pair is.
 
 3. **DHCP lease dependency** -- Device names and MACs are resolved from `/tmp/dhcp.leases`. Devices with static IPs that bypass DHCP will show as IP addresses only.
 

--- a/luci-app-trafficctl/root/usr/local/bin/trafficctl-bytes.sh
+++ b/luci-app-trafficctl/root/usr/local/bin/trafficctl-bytes.sh
@@ -12,20 +12,35 @@
 _offload=$(tctl_get_offload_mode)
 [ "$_offload" != "none" ] && [ "$TCTL_FW" = "nft" ] && exec /usr/local/bin/trafficctl-bytes-nft.sh
 
-LAN_DEV=$(tctl_get_lan_device)
-LAN_SUBNET=$(ip -4 addr show dev "$LAN_DEV" 2>/dev/null | grep -oE 'inet [0-9.]+' | head -1 | awk '{print $2}')
-LAN_PREFIX=$(echo "$LAN_SUBNET" | cut -d. -f1-3)
+# All LAN subnets (multi-bridge / multi-VLAN aware), as awk membership spec.
+MATCH_SPEC=$(tctl_lan_subnets | awk '{printf "%s%s:%s:%s",(NR>1?" ":""),$2,$3,$4}')
+[ -z "$MATCH_SPEC" ] && { echo '[]'; exit 0; }
 
-[ -z "$LAN_PREFIX" ] && { echo '[]'; exit 0; }
-
-cat /proc/net/nf_conntrack 2>/dev/null | awk -v prefix="$LAN_PREFIX" '
-BEGIN { printf "[" }
+cat /proc/net/nf_conntrack 2>/dev/null | awk -v spec="$MATCH_SPEC" '
+function ip2int(ip,   a) {
+    split(ip, a, ".")
+    return a[1]*16777216 + a[2]*65536 + a[3]*256 + a[4]
+}
+function is_lan(ip,   si, k) {
+    si = ip2int(ip)
+    for (k = 1; k <= ns; k++)
+        if (si - (si % blk[k]) == base[k]) return 1
+    return 0
+}
+BEGIN {
+    printf "["
+    ns = split(spec, parts, " ")
+    for (k = 1; k <= ns; k++) {
+        split(parts[k], kv, ":")
+        base[k] = kv[1] + 0; blk[k] = kv[2] + 0
+    }
+}
 {
     src=""; bytes_orig=0; bytes_reply=0; bc=0
     for (i=1; i<=NF; i++) {
         if ($i ~ /^src=/) {
             v = substr($i, 5)
-            if (v ~ "^"prefix"\\." && src == "") src = v
+            if (src == "" && is_lan(v)) src = v
         }
         if ($i ~ /^bytes=/) {
             v = substr($i, 7) + 0
@@ -34,7 +49,7 @@ BEGIN { printf "[" }
             else if (src != "" && bc == 2) bytes_reply = v
         }
     }
-    if (src != "" && src ~ "^"prefix"\\.") {
+    if (src != "") {
         key = src
         in_total[key] += bytes_reply
         out_total[key] += bytes_orig

--- a/luci-app-trafficctl/root/usr/local/bin/trafficctl-fw.sh
+++ b/luci-app-trafficctl/root/usr/local/bin/trafficctl-fw.sh
@@ -107,6 +107,50 @@ tctl_get_lan_device() {
     echo "$dev"
 }
 
+# Enumerate all LAN-side IPv4 subnets, one per L3 interface.
+#
+# "LAN" = firewall zones that are NOT internet-facing. A zone is treated as LAN
+# if it is named "lan", or if it is neither a wan zone nor masqueraded. This
+# deliberately excludes VPN/tunnel zones (e.g. WireGuard/AmneziaWG awg*, which
+# carry their own IPv4 and would otherwise be mistaken for LANs) because those
+# are masqueraded out. Covers bridges (br-lan), bridge-VLANs and plain VLAN
+# interfaces (eth0.20) uniformly via each interface's l3_device.
+#
+# Output: one line per subnet, "l3_device netbase_int block_size router_int"
+# where membership can be tested without awk bit-ops:
+#   ip in subnet  <=>  ipint - (ipint % block) == netbase
+tctl_lan_subnets() {
+    local i=0 zname zmasq nets net st l3 addr mask
+    local o1 o2 o3 o4 ipint block netbase
+    while zname=$(uci -q get "firewall.@zone[$i].name" 2>/dev/null); [ -n "$zname" ]; do
+        zmasq=$(uci -q get "firewall.@zone[$i].masq" 2>/dev/null)
+        nets=$(uci -q get "firewall.@zone[$i].network" 2>/dev/null)
+        i=$((i + 1))
+        case "$zname" in wan|wan6) continue ;; esac
+        [ "$zname" != "lan" ] && [ "$zmasq" = "1" ] && continue
+        for net in $nets; do
+            st=$(ubus call "network.interface.$net" status 2>/dev/null)
+            l3=$(echo "$st" | jsonfilter -e '@.l3_device' 2>/dev/null)
+            addr=$(echo "$st" | jsonfilter -e '@["ipv4-address"][0].address' 2>/dev/null)
+            mask=$(echo "$st" | jsonfilter -e '@["ipv4-address"][0].mask' 2>/dev/null)
+            [ -n "$l3" ] && [ -n "$addr" ] && [ -n "$mask" ] || continue
+            [ "$mask" -ge 1 ] && [ "$mask" -le 32 ] 2>/dev/null || continue
+            o1=${addr%%.*}; rest=${addr#*.}
+            o2=${rest%%.*}; rest=${rest#*.}
+            o3=${rest%%.*}; o4=${rest##*.}
+            ipint=$(( (o1 << 24) + (o2 << 16) + (o3 << 8) + o4 ))
+            block=$(( 1 << (32 - mask) ))
+            netbase=$(( ipint - (ipint % block) ))
+            echo "$l3 $netbase $block $ipint"
+        done
+    done
+}
+
+# LAN L3 device names only (deduplicated), e.g. "br-lan br-guest eth0.20".
+tctl_get_lan_devices() {
+    tctl_lan_subnets | awk '{print $1}' | sort -u
+}
+
 tctl_validate_ip() {
     echo "$1" | grep -qE '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$' || return 1
     local IFS='.'

--- a/luci-app-trafficctl/root/usr/local/bin/trafficctl-summary.sh
+++ b/luci-app-trafficctl/root/usr/local/bin/trafficctl-summary.sh
@@ -11,8 +11,6 @@
 
 . /usr/local/bin/trafficctl-fw.sh
 
-LAN_DEV=$(tctl_get_lan_device)
-LAN_SUBNET=$(ip -4 addr show dev "$LAN_DEV" 2>/dev/null | grep -oE 'inet [0-9.]+/[0-9]+' | head -1 | awk '{print $2}')
 CONN_CACHE="/tmp/trafficctl_conn_cache"
 [ -f "$CONN_CACHE" ] || : > "$CONN_CACHE"
 
@@ -20,10 +18,14 @@ PORT_MAP_FILE="/tmp/.trafficctl_portmap.$$"
 # shellcheck disable=SC2064
 trap "rm -f '$PORT_MAP_FILE'" EXIT INT TERM
 
-LAN_PREFIX=$(echo "$LAN_SUBNET" | cut -d. -f1-3)
-LAN_IP=$(echo "$LAN_SUBNET" | cut -d/ -f1)
-
-[ -z "$LAN_PREFIX" ] && { echo '[]'; exit 0; }
+# Enumerate every LAN subnet (multi-bridge / multi-VLAN aware), once.
+LAN_SUBNETS=$(tctl_lan_subnets)
+[ -z "$LAN_SUBNETS" ] && { echo '[]'; exit 0; }
+LAN_DEVS=$(echo "$LAN_SUBNETS" | awk '{print $1}' | sort -u)
+# Membership spec for awk: "netbase:block:routerint ..." (no awk bit-ops needed)
+MATCH_SPEC=$(echo "$LAN_SUBNETS" | awk '{printf "%s%s:%s:%s",(NR>1?" ":""),$2,$3,$4}')
+# Device that carries the tc/HTB shaper (shaping is single-bridge by design).
+PRIMARY_LAN_DEV=$(tctl_get_lan_device)
 
 # Get WiFi station→interface mapping: "mac iface_name band"
 get_wifi_stations() {
@@ -45,23 +47,27 @@ get_wifi_stations() {
     done
 }
 
-# Get bridge MAC→port interface mapping: "mac port_iface"
+# Get bridge MAC→port interface mapping across all LAN bridges: "mac port_iface"
 get_bridge_macs() {
-    for pdir in /sys/class/net/"$LAN_DEV"/brif/*/; do
-        [ -d "$pdir" ] || continue
-        local iface pno
-        iface=$(basename "$pdir")
-        pno=$(cat "${pdir}port_no" 2>/dev/null)
-        [ -z "$pno" ] && continue
-        printf "%d %s\n" "$(( pno ))" "$iface"
-    done > "$PORT_MAP_FILE"
-    brctl showmacs "$LAN_DEV" 2>/dev/null | awk -v pmf="$PORT_MAP_FILE" '
-    BEGIN { while ((getline line < pmf) > 0) { split(line, p, " "); portname[p[1]] = p[2] } }
-    NR > 1 && $3 == "no" {
-        mac = tolower($2)
-        port = $1 + 0
-        if (port in portname) print mac, portname[port]
-    }'
+    local dev
+    for dev in $LAN_DEVS; do
+        [ -d "/sys/class/net/$dev/brif" ] || continue
+        for pdir in /sys/class/net/"$dev"/brif/*/; do
+            [ -d "$pdir" ] || continue
+            local iface pno
+            iface=$(basename "$pdir")
+            pno=$(cat "${pdir}port_no" 2>/dev/null)
+            [ -z "$pno" ] && continue
+            printf "%d %s\n" "$(( pno ))" "$iface"
+        done > "$PORT_MAP_FILE"
+        brctl showmacs "$dev" 2>/dev/null | awk -v pmf="$PORT_MAP_FILE" '
+        BEGIN { while ((getline line < pmf) > 0) { split(line, p, " "); portname[p[1]] = p[2] } }
+        NR > 1 && $3 == "no" {
+            mac = tolower($2)
+            port = $1 + 0
+            if (port in portname) print mac, portname[port]
+        }'
+    done
     rm -f "$PORT_MAP_FILE"
 }
 
@@ -69,23 +75,44 @@ get_bridge_macs() {
 # Emit "ip total tcp udp conns" for every active LAN source in one read,
 # replicating the previous per-IP accounting (original-direction bytes of the
 # first tuple that belongs to a LAN device). Replaces N full conntrack reads.
-CT_SUMMARY=$(awk -v prefix="$LAN_PREFIX" -v lanip="$LAN_IP" '
+CT_SUMMARY=$(awk -v spec="$MATCH_SPEC" '
+function ip2int(ip,   a) {
+    split(ip, a, ".")
+    return a[1]*16777216 + a[2]*65536 + a[3]*256 + a[4]
+}
+# Return the index of the LAN subnet that contains ip, or 0.
+function lan_idx(ip,   si, k) {
+    si = ip2int(ip)
+    for (k = 1; k <= ns; k++)
+        if (si - (si % blk[k]) == base[k]) return k
+    return 0
+}
+BEGIN {
+    ns = split(spec, parts, " ")
+    for (k = 1; k <= ns; k++) {
+        split(parts[k], kv, ":")
+        base[k] = kv[1] + 0; blk[k] = kv[2] + 0; rtr[k] = kv[3] + 0
+    }
+}
 {
     proto=""
     for (i=1; i<=NF; i++) {
         if ($i == "tcp") proto="tcp"
         else if ($i == "udp") proto="udp"
     }
-    # first src= field whose value is on the LAN
-    srcidx=0; src=""
+    # first src= field that belongs to one of our LAN subnets
+    srcidx=0; src=""; sk=0
     for (i=1; i<=NF; i++) {
         if (index($i, "src=") == 1) {
             v=substr($i, 5)
-            if (v ~ "^"prefix"\\.") { src=v; srcidx=i; break }
+            k=lan_idx(v)
+            if (k > 0) { src=v; srcidx=i; sk=k; break }
         }
     }
-    if (src == "" || src == lanip) next
-    if (src ~ /\.255$/) next
+    if (src == "") next
+    si=ip2int(src)
+    # skip the router itself, the network address and the broadcast address
+    if (si == rtr[sk] || si == base[sk] || si == base[sk] + blk[sk] - 1) next
     seen=0; got_dst=0; found=0; b=0
     for (i=srcidx; i<=NF; i++) {
         if (i == srcidx) { seen=1; continue }
@@ -111,7 +138,7 @@ END {
         printf "%s %d %d %d %d\n", ip, total[ip]+0, tcp[ip]+0, udp[ip]+0, conns[ip]
 }' /proc/net/nf_conntrack 2>/dev/null)
 
-ACTIVE_IPS=$(echo "$CT_SUMMARY" | awk 'NF{print $1}')
+ACTIVE_IPS=$(echo "$CT_SUMMARY" | awk 'NF{print $1}' | sort -t. -k1,1n -k2,2n -k3,3n -k4,4n)
 [ -z "$ACTIVE_IPS" ] && { echo '[]'; exit 0; }
 
 # ── Prefetch all shared state once ─────────────────────────────────────────
@@ -131,7 +158,7 @@ fi
 # tc HTB classes → "classid rate_kbit" map (one tc call, parsed once)
 TC_MAP=""
 if command -v tc >/dev/null 2>&1; then
-    TC_MAP=$(tc class show dev "$LAN_DEV" 2>/dev/null | awk '
+    TC_MAP=$(tc class show dev "$PRIMARY_LAN_DEV" 2>/dev/null | awk '
     /^class htb 1:/ {
         classid=$3
         minor=classid; sub(/^1:/,"",minor)


### PR DESCRIPTION
Stacked on #14 (base `perf/summary-single-pass`) — GitHub will retarget this to `main` once #14 merges. Review/merge #14 first.

## Closes #13 — devices on secondary bridges / VLANs were invisible

The backend assumed a single LAN: `tctl_get_lan_device()` returned one device and `summary.sh`/`bytes.sh` filtered conntrack to that one /24. Any device on a second bridge (`br-lan2`, guest) or a tagged VLAN was dropped before display — the reporter's "can't see IP from this interface."

## Approach: enumerate LAN subnets by firewall zone

New `tctl_lan_subnets()` walks firewall zones; a zone is LAN if it is named `lan` **or** is neither a wan zone nor masqueraded. Each interface's `l3_device` + IPv4 is resolved via `ubus`, so bridges, bridge-VLANs and plain VLAN ifaces (`eth0.20`) are handled uniformly.

**Why zone-based, not "any non-WAN L3 interface":** verified against a live router — a naive rule would have listed the AmneziaWG tunnels `awg0-3` as LANs (they carry `10.x/32` addresses), but they sit in the masqueraded `wan` zone and are correctly excluded:

```
zone[0] name=lan  masq=   network=[lan]            -> br-lan 192.168.0.0/24  ✅ included
zone[1] name=wan  masq=1  network=[wan awg0..awg3] -> excluded
zone[2] name=vpn  masq=1  network=[vpn vpn6]       -> excluded
tctl_lan_subnets => "br-lan 3232235520 256 3232235521"   (only br-lan)
```

`summary.sh` and `bytes.sh` now test conntrack sources for membership in *any* LAN subnet via a masked compare done without awk bit-ops (works on BusyBox awk), and the bridge-port→MAC map is built across every LAN bridge.

## Tested
- [x] **Regression:** single-/24 output byte-for-byte identical to #14 (mocked nft/tc/uci/ip env)
- [x] **Multi-subnet:** a device on a second /24 (`192.168.1.0/24`) now appears in both `summary.sh` and `bytes.sh`; before it was dropped
- [x] `tctl_lan_subnets()` run on real hardware → only `br-lan`, AmneziaWG/vpn excluded
- [x] dash `-n` + shellcheck clean on fw.sh / summary.sh / bytes.sh

## Note on #10 (egress interface per connection)
Investigated and **not included here** — verification on a policy-routing router showed conntrack carries `mark=0` (no restored connmark), `ip route get <dst> mark 0` returns `lo`, and the mark-less lookup reports the main-table egress (`wan`) even for tunnel-routed destinations. A generic egress column can't be made reliably correct; it only works where the router restores connmark (mwan3). Proposing to answer #10 on the tracker instead. Details in PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)