### PR TITLE
ci: make all checks strict — stop tolerating warnings & masked failures

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,17 +26,17 @@
     "view": "readonly"
   },
   "rules": {
-    "no-unused-vars": ["warn", { "args": "none", "varsIgnorePattern": "^_" }],
+    "no-unused-vars": ["error", { "args": "none", "varsIgnorePattern": "^_" }],
     "no-undef": "error",
     "no-redeclare": "error",
-    "no-constant-condition": "warn",
-    "no-empty": ["warn", { "allowEmptyCatch": true }],
+    "no-constant-condition": "error",
+    "no-empty": ["error", { "allowEmptyCatch": true }],
     "no-extra-semi": "error",
     "no-unreachable": "error",
-    "eqeqeq": ["warn", "smart"],
+    "eqeqeq": ["error", "smart"],
     "no-var": "off",
     "prefer-const": "off",
     "semi": ["error", "always"],
-    "curly": ["warn", "multi-line"]
+    "curly": ["error", "multi-line"]
   }
 }

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -177,6 +177,10 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           sed -i "s/^PKG_VERSION:=.*/PKG_VERSION:=${{ steps.bump.outputs.new_version }}/" luci-app-trafficctl/Makefile
           sed -i "s/^PKG_RELEASE:=.*/PKG_RELEASE:=1/" luci-app-trafficctl/Makefile
+          # Fail loudly if the substitution did not take (e.g. Makefile format
+          # changed) instead of tagging a release with an unbumped version.
+          grep -qx "PKG_VERSION:=${{ steps.bump.outputs.new_version }}" luci-app-trafficctl/Makefile \
+            || { echo "ERROR: PKG_VERSION was not updated in the Makefile"; exit 1; }
           git add luci-app-trafficctl/Makefile
           git commit -m "chore: bump version to ${{ steps.bump.outputs.new_version }}"
           git tag "${{ steps.bump.outputs.new_tag }}"

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -167,17 +167,10 @@ jobs:
   feed-install:
     name: Feed install (SDK ${{ matrix.version }})
     runs-on: ubuntu-latest
-    # ──────────────────────────────────────────────────────────────────────────
-    # Non-blocking due to SDK environment limitation (issue #7 reproduction):
-    # The lucihttp feed dependency fails to compile in the OpenWrt SDK because
-    # lua.h headers aren't pre-installed in openwrt/sdk container images. This is
-    # an SDK environment issue, NOT a bug in our package. The test still provides
-    # value (catches issue #7 regression if the restructure breaks), but we mark
-    # it non-blocking to avoid blocking PR merges on every run.
-    # TODO: pre-install lua-dev / ucode-dev in the SDK before running feed
-    # compile, then remove continue-on-error.
-    # ──────────────────────────────────────────────────────────────────────────
-    continue-on-error: true
+    # The earlier lua.h SDK-environment problem is worked around in
+    # test_feed_install.sh (it disables the liblucihttp-lua/ucode deps), so this
+    # job now passes on every supported SDK and is a BLOCKING check again —
+    # a feed-install regression (e.g. issue #7 recurring) must fail CI.
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -20,4 +20,6 @@ jobs:
         with:
           node-version: '20'
       - run: npm ci
-      - run: npx eslint luci-app-trafficctl/htdocs/
+      # --max-warnings 0 makes ANY eslint warning fail CI (defence in depth on
+      # top of the config promoting rules to "error").
+      - run: npx eslint --max-warnings 0 luci-app-trafficctl/htdocs/

--- a/.github/workflows/feature-build.yml
+++ b/.github/workflows/feature-build.yml
@@ -126,25 +126,25 @@ jobs:
             --prerelease \
             --title "Dev: ${BRANCH} @ ${SHA}" \
             --notes "$(cat <<NOTES
-## Dev build — \`${BRANCH}\`
+          ## Dev build — \`${BRANCH}\`
 
-Built from [\`${SHA}\`](https://github.com/${REPO}/commit/${GITHUB_SHA}) · ${DATE}
+          Built from [\`${SHA}\`](https://github.com/${REPO}/commit/${GITHUB_SHA}) · ${DATE}
 
-> ⚠️ Pre-release for testing only — not for production.
+          > ⚠️ Pre-release for testing only — not for production.
 
-| File | OpenWrt version | Command |
-|------|----------------|---------|
-| \`luci-app-trafficctl.ipk\` | 21.02 – 24.10 | \`opkg install <url>\` |
-| \`luci-app-trafficctl.apk\` | 25.12+ | \`apk add --allow-untrusted <url>\` |
+          | File | OpenWrt version | Command |
+          |------|----------------|---------|
+          | \`luci-app-trafficctl.ipk\` | 21.02 – 24.10 | \`opkg install <url>\` |
+          | \`luci-app-trafficctl.apk\` | 25.12+ | \`apk add --allow-untrusted <url>\` |
 
-### Install
+          ### Install
 
-\`\`\`sh
-# OpenWrt 21.02 – 24.10
-opkg install https://github.com/${REPO}/releases/download/${TAG}/luci-app-trafficctl.ipk
+          \`\`\`sh
+          # OpenWrt 21.02 – 24.10
+          opkg install https://github.com/${REPO}/releases/download/${TAG}/luci-app-trafficctl.ipk
 
-# OpenWrt 25.12+
-apk add --allow-untrusted https://github.com/${REPO}/releases/download/${TAG}/luci-app-trafficctl.apk
-\`\`\`
-NOTES
-)"
+          # OpenWrt 25.12+
+          apk add --allow-untrusted https://github.com/${REPO}/releases/download/${TAG}/luci-app-trafficctl.apk
+          \`\`\`
+          NOTES
+          )"

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -58,7 +58,11 @@ jobs:
       - name: Verify target release exists
         run: |
           TAG="v${{ inputs.version }}"
-          gh release view "$TAG" || echo "::warning::Release $TAG not found, will create it"
+          # This workflow REBUILDS an existing release; the later
+          # `gh release upload --clobber` cannot create a missing one and would
+          # fail after a full build. Fail fast and clearly instead.
+          gh release view "$TAG" >/dev/null \
+            || { echo "::error::Release $TAG does not exist — nothing to rebuild"; exit 1; }
 
       - name: Locate and patch Makefile
         run: |

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -16,10 +16,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@2.0.0
-        with:
-          scandir: luci-app-trafficctl/root/usr/local/bin
-          additional_files: luci-app-trafficctl/root/etc/hotplug.d/iface/99-trafficctl-shapes luci-app-trafficctl/root/usr/libexec/rpcd/luci.trafficctl luci-app-trafficctl/root/etc/init.d/trafficctl-telegram
-        env:
-          SHELLCHECK_OPTS: -x -e SC1091
+      # Explicit scan of EVERY shell script (detected by shebang), failing on
+      # any warning or error. The previous ludeeus/action-shellcheck step only
+      # scanned root/usr/local/bin: its `additional_files` were passed as full
+      # paths but the action treats them as `find -name` basename globs, so the
+      # init.d / rpcd / hotplug scripts were silently never checked.
+      - name: Run ShellCheck (warnings fail)
+        run: |
+          shellcheck --version
+          mapfile -t files < <(
+            grep -rlE '^#!.*(sh|bash|dash|ash)' \
+              luci-app-trafficctl/root build-ipk.sh build-apk.sh tests \
+              | grep -v node_modules | sort -u
+          )
+          echo "Scanning ${#files[@]} shell scripts:"
+          printf '  %s\n' "${files[@]}"
+          shellcheck -x -e SC1091 -S warning "${files[@]}"

--- a/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.js
+++ b/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.js
@@ -1373,54 +1373,6 @@ return view.extend({
 			return E('span', { 'class': 'tc-inline-label' }, t);
 		}
 
-		function mkInlinePick(options, currentValue, onChange) {
-			var wrapper = E('span', {'class':'tc-inline-pick-wrapper'});
-			var display = E('span', {'class':'tc-inline-pick-display'});
-			var popup = E('div', {'class':'tc-inline-pick-popup tc-hidden'});
-			var selectedValue = currentValue;
-
-			function updateDisplay() {
-				var label = selectedValue;
-				for (var i = 0; i < options.length; i++) {
-					if (options[i].v === selectedValue) { label = options[i].l; break; }
-				}
-				display.textContent = label;
-			}
-
-			function buildPopup() {
-				while (popup.firstChild) popup.removeChild(popup.firstChild);
-				options.forEach(function(opt) {
-					var active = opt.v === selectedValue;
-					var item = E('div', {
-						'style': 'padding:4px 14px;cursor:pointer;font-size:12px;' +
-							(active ? 'color:var(--tc-speed);font-weight:600;background:var(--tc-hover)' : 'color:currentColor')
-					}, opt.l);
-					item.addEventListener('mousedown', function(ev) {
-						ev.preventDefault();
-						selectedValue = opt.v;
-						updateDisplay();
-						popup.classList.add('tc-hidden');
-						onChange(opt.v);
-					});
-					item.addEventListener('mouseenter', function() { this.style.background = 'var(--tc-hover)'; });
-					item.addEventListener('mouseleave', function() { this.style.background = active ? 'var(--tc-hover)' : ''; });
-					popup.appendChild(item);
-				});
-			}
-
-			display.addEventListener('click', function(ev) {
-				ev.stopPropagation();
-				buildPopup();
-				popup.classList.toggle('tc-hidden');
-			});
-			document.addEventListener('click', function() { popup.classList.add('tc-hidden'); });
-
-			wrapper.appendChild(display);
-			wrapper.appendChild(popup);
-			updateDisplay();
-			return { el: wrapper, getValue: function() { return selectedValue; }, setValue: function(v) { selectedValue = v; updateDisplay(); } };
-		}
-
 		function mkChipPick(options, currentValue, onChange) {
 			var wrapper = E('span', {'style':'display:inline-flex;flex-wrap:wrap;gap:2px;align-items:center'});
 			var selected = currentValue;
@@ -1745,8 +1697,6 @@ return view.extend({
 			setValue: function(v) { _modeSelected = v; updateModeToggle(); },
 			el: modeToggle
 		};
-		var rateBtn = { disabled: false, addEventListener: function() {} };
-
 		function getRateKbit() {
 			if (_rateSelected !== 'custom') return _rateSelected;
 			var n = parseFloat(customInput.value);
@@ -2187,9 +2137,11 @@ return view.extend({
 			parts.push(E('span', {}, [document.createTextNode(_('WiFi') + ': '), mkFilterVal('wifi_blocked', 'var(--tc-warn)', String(wifiBlk))]));
 			if (limited > 0) parts.push(E('span', {}, [document.createTextNode(_('Limited') + ': '), mkFilterVal('limited', 'var(--tc-warn)', '⚡' + limited)]));
 			if (shaped > 0) parts.push(E('span', {}, [document.createTextNode(_('Shaped') + ': '), mkFilterVal('shaped', 'var(--tc-speed)', '🌊' + shaped)]));
-			if (totalDropPkts > 0) parts.push(E('span', {}, [
-				document.createTextNode(_('Dropped') + ': '), E('b', {'style':'color:var(--tc-err)'}, '🚫' + totalDropPkts)
-			]));
+			if (totalDropPkts > 0) {
+				parts.push(E('span', {}, [
+					document.createTextNode(_('Dropped') + ': '), E('b', {'style':'color:var(--tc-err)'}, '🚫' + totalDropPkts)
+				]));
+			}
 
 			parts.forEach(function(el, i) {
 				if (i > 0) statsDiv.appendChild(E('span', {'style':'margin:0 6px;color:var(--tc-faint)'}, '|'));
@@ -2970,8 +2922,6 @@ return view.extend({
 				el.textContent = 'trafficctl v' + res.version + ' (' + TRAFFICCTL_BUILD + ')';
 			}
 		});
-
-		var docsUrl = 'https://openwrt.org/docs/guide-user/perf_and_log/flow_offloading';
 
 		var mkOffloadBanner = function(mode) {
 			if (!mode || mode === 'none') return null;

--- a/luci-app-trafficctl/root/etc/hotplug.d/dhcp/99-trafficctl-newdevice
+++ b/luci-app-trafficctl/root/etc/hotplug.d/dhcp/99-trafficctl-newdevice
@@ -17,4 +17,7 @@ grep -q "\"$MACADDR\"" "$KNOWN_FILE" 2>/dev/null && exit 0
 
 # Signal the bot by writing to a trigger file
 mkdir -p "$(dirname "$NOTIFY_FLAG")"
+# HOSTNAME comes from the dnsmasq dhcp hotplug environment (see header), not a
+# POSIX shell builtin — so shellcheck's SC3028 is a false positive here.
+# shellcheck disable=SC3028
 printf '%s\t%s\t%s\n' "$MACADDR" "${IPADDR:-?}" "${HOSTNAME:-unknown}" >> "$NOTIFY_FLAG"

--- a/luci-app-trafficctl/root/etc/init.d/trafficctl-telegram
+++ b/luci-app-trafficctl/root/etc/init.d/trafficctl-telegram
@@ -1,6 +1,7 @@
 #!/bin/sh /etc/rc.common
 # shellcheck shell=dash
-
+# START/STOP/USE_PROCD are consumed by the sourced /etc/rc.common framework.
+# shellcheck disable=SC2034
 START=99
 STOP=10
 USE_PROCD=1

--- a/tests/test_build_ipk.sh
+++ b/tests/test_build_ipk.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Integration test: verify build-ipk.sh produces a valid ipk.
 
 set -e

--- a/tests/test_feed_install.sh
+++ b/tests/test_feed_install.sh
@@ -65,7 +65,10 @@ echo "Running scripts/feeds install -a..."
 
 # Verify the package was registered with the buildroot
 echo "Verifying package is known to buildroot..."
-make defconfig V=s 2>&1 | tail -20
+make defconfig V=s > /tmp/tctl_defconfig.log 2>&1 || {
+    tail -20 /tmp/tctl_defconfig.log; echo "ERROR: make defconfig failed"; exit 1
+}
+tail -20 /tmp/tctl_defconfig.log
 if ! grep -q "luci-app-trafficctl" .config 2>/dev/null; then
     echo "Enabling package in .config..."
     echo 'CONFIG_PACKAGE_luci-app-trafficctl=m' >> .config
@@ -77,7 +80,15 @@ echo 'CONFIG_PACKAGE_liblucihttp-ucode=n' >> .config
 make defconfig
 
 echo "Building package..."
-make package/luci-app-trafficctl/compile V=s -j"$(nproc)" 2>&1 | tail -50
+# Capture make's real exit code — a `make … | tail` pipeline returns tail's
+# status (0), which under set -e would silently hide a genuine build failure.
+# This matters now that the feed-install job is blocking (no continue-on-error).
+if ! make package/luci-app-trafficctl/compile V=s -j"$(nproc)" > /tmp/tctl_compile.log 2>&1; then
+    tail -80 /tmp/tctl_compile.log
+    echo "ERROR: make compile failed"
+    exit 1
+fi
+tail -50 /tmp/tctl_compile.log
 
 # Verify build artifact exists
 FOUND=$(find bin/ -name "luci-app-trafficctl*" \( -name "*.ipk" -o -name "*.apk" \) 2>/dev/null | head -1)

--- a/tests/test_openwrt_compat.sh
+++ b/tests/test_openwrt_compat.sh
@@ -78,13 +78,13 @@ check_bashism "$REPO_ROOT/luci-app-trafficctl/root/usr/libexec/rpcd/luci.traffic
 
 # ── IPK build and structure ────────────────────────────────────────────────
 
-cd "$REPO_ROOT"
+cd "$REPO_ROOT" || exit 1
 IPK=$(./build-ipk.sh 0.0.0-test 1 2>/dev/null)
 assert_eq "ipk builds" "yes" "$([ -f "$IPK" ] && echo yes || echo no)"
 
 if [ -f "$IPK" ]; then
     TMPDIR=$(mktemp -d)
-    cd "$TMPDIR"
+    cd "$TMPDIR" || exit 1
     tar xzf "$REPO_ROOT/$IPK"
 
     # Verify all critical files in data.tar.gz
@@ -116,7 +116,7 @@ if [ -f "$IPK" ]; then
     assert_ok "conffiles has trafficctl" grep -q "/etc/config/trafficctl" conffiles
     assert_ok "postinst is executable" test -x postinst
 
-    cd "$REPO_ROOT"
+    cd "$REPO_ROOT" || exit 1
     rm -rf "$TMPDIR" dist/
 fi
 

--- a/tests/test_telegram_e2e.sh
+++ b/tests/test_telegram_e2e.sh
@@ -43,7 +43,6 @@ assert_file_contains() {
 # ── Setup mock environment ─────────────────────────────────────────────────────
 
 setup_env() {
-    local testname="$1"
     MOCKDIR=$(mktemp -d)
     MOCKBIN="$MOCKDIR/bin"
     MOCKDATA="$MOCKDIR/data"

--- a/tests/test_telegram_mock.sh
+++ b/tests/test_telegram_mock.sh
@@ -5,7 +5,6 @@
 
 PASS=0
 FAIL=0
-SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)/root/usr/local/bin"
 TMPDIR=$(mktemp -d)
 trap 'rm -rf "$TMPDIR"' EXIT
 


### PR DESCRIPTION
You flagged that CI shows green while tolerating warnings that should be errors. Audited every check (three parallel sub-agents + manual verification) and fixed the gaps. Each fix is its own commit.

## What was lying about being green

**1. ESLint** — ran `npx eslint` with no `--max-warnings`, and the config marked rules as `warn`, so 4 real problems passed: dead `mkInlinePick` (47-line unused fn), unused `rateBtn`/`docsUrl`, a braceless multi-line `if`.
→ removed the dead code, promoted the rules to `error`, added `--max-warnings 0`. Verified clean.

**2. ShellCheck** — only `root/usr/local/bin` was actually scanned. `additional_files` was passed full paths but the action treats it as `find -name` basename globs → **init.d, rpcd backend and the iface hotplug script were never checked**; build scripts, the dhcp hotplug script and all of `tests/` were uncovered too.
→ replaced with an explicit step that discovers every shell script by shebang and runs `shellcheck -x -e SC1091 -S warning` (warnings fail). Fixed the findings this surfaced (SC3028, SC2034, SC3043, SC2164). All 35 scripts now pass.

**3. feature-build.yml — failed on *every* run.** A heredoc body inside a `run: |` block was at column 0, so YAML ended the scalar early and GitHub rejected the file at parse time (no jobs ever ran).
→ indented the heredoc to the block-scalar level; file now parses.

**4. compat.yml feed-install** carried `continue-on-error: true` (any regression reported green; verified the job genuinely passes now) **and** `make … | tail` swallowed make's exit code.
→ made the job blocking and capture make's real exit status.

**5. Release workflows** — `auto-release` never checked the version `sed` took (could tag an unbumped release); `manual-release` only warned on a missing release then failed late.
→ verify the bump; fail fast.

## Deliberately NOT included — needs a call
**`test_install.sh --allow-untrusted`** (the APK install). Replacing it with real signature verification needs the public key mounted into each test container **and** confidence that the committed `keys/apk-signing.pub` matches the `secrets.APK_PRIVATE_KEY` used to sign — neither verifiable locally, and getting it wrong reddens the whole APK matrix. Unlike the others this doesn't mask a *failing* check (it's a standard local-build test convenience). Left as-is; can be done as a separate, CI-tested change.

## Verified locally
- `npx eslint --max-warnings 0 …` → 0 problems
- `shellcheck -x -e SC1091 -S warning` over all 35 scripts → clean
- all six modified workflow YAMLs parse