### PR TITLE
ci: bump actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -46,7 +46,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v5
         with:
           name: packages
           path: dist/
@@ -121,8 +121,8 @@ jobs:
           - { version: "snapshot", arch: "armsr",     image: "armsr-armv8-snapshot" }
     steps:
       - uses: actions/checkout@v6
-      - uses: docker/setup-qemu-action@v3
-      - uses: actions/download-artifact@v4
+      - uses: docker/setup-qemu-action@v4
+      - uses: actions/download-artifact@v5
         with:
           name: packages
           path: dist/
@@ -213,7 +213,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: packages
           path: dist/
@@ -274,7 +274,7 @@ jobs:
           - { version: "25.12.4", image: "x86-64-v25.12.4", format: "apk" }
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           name: packages
           path: dist/

--- a/.github/workflows/feature-build.yml
+++ b/.github/workflows/feature-build.yml
@@ -50,7 +50,7 @@ jobs:
         run: sh tests/test_build_ipk.sh
 
       - name: Upload IPK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ipk
           path: dist/luci-app-trafficctl.ipk
@@ -88,7 +88,7 @@ jobs:
           cp "$APK" luci-app-trafficctl.apk
 
       - name: Upload APK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: apk
           path: luci-app-trafficctl.apk
@@ -103,7 +103,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           merge-multiple: true
           path: dist/


### PR DESCRIPTION
Bumps actions/download-artifact v4→v5, actions/upload-artifact v4→v5, docker/setup-qemu-action v3→v4 to clear the ~58 'Node.js 20 is deprecated' warning annotations the OpenWrt Compatibility run emits (one per job). No behaviour change. The install/upgrade test ::warning:: annotations are intentionally left as-is (they flag a real masked opkg-install failure tracked separately).