### PR TITLE
feat(device): show egress interface per connection (mwan3) — closes #10

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -127,13 +127,22 @@ Returns detailed connection information for a single device.
       "port": 443,
       "service": "https",
       "bytes": 17261,
-      "state": "ESTABLISHED"
+      "state": "ESTABLISHED",
+      "oif": "wan2"
     }
   ],
   "rate_limit_kbit": 0,
   "shape_kbit": 10000
 }
 ```
+
+Each connection's `oif` is the egress interface, resolved via
+`ip route get <dst> mark <mark>` from the connection's conntrack fwmark. It is
+only populated for **policy-routed** connections (a non-zero connmark, e.g.
+mwan3, which restores the routing mark). For connections with mark `0` (plain
+single-WAN, or policy-routing that doesn't restore the connmark such as podkop)
+`oif` is empty. The LuCI connections table exposes it as an optional, hidden-by-default
+"Iface" column.
 
 ---
 

--- a/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.js
+++ b/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.js
@@ -674,7 +674,8 @@ function buildTable(conns, sortCol, sortDir, rdnsMode, hiddenCols) {
 		{ key:'port',    label: _('Port'),     num:true  },
 		{ key:'service', label: _('Service'),  num:false },
 		{ key:'bytes',   label: _('Bytes'),    num:true  },
-		{ key:'state',   label: _('State'),    num:false }
+		{ key:'state',   label: _('State'),    num:false },
+		{ key:'oif',     label: _('Iface'),    num:false }
 	];
 	var hid = hiddenCols || {};
 	var cols = allCols.filter(function(c) { return !hid[c.key]; });
@@ -717,7 +718,8 @@ function buildTable(conns, sortCol, sortDir, rdnsMode, hiddenCols) {
 			port:    E('div', { 'class': 'td tc-right tc-mono' }, String(r.port || '')),
 			service: E('div', { 'class': 'td tc-c-speed' }, escHtml(r.service || (SERVICE_PORTS[r.port]||''))),
 			bytes:   E('div', { 'class': 'td tc-right tc-mono tc-fw-bold' }, fmtBytes(r.bytes)),
-			state:   E('div', { 'class': 'td tc-fw-bold' + scCls }, state)
+			state:   E('div', { 'class': 'td tc-fw-bold' + scCls }, state),
+			oif:     E('div', { 'class': 'td tc-mono' }, r.oif ? escHtml(r.oif) : E('span', { 'class': 'tc-c-faint' }, '—'))
 		};
 		var cells = cols.map(function(c) { return cellMap[c.key]; });
 		return E('div', { 'class': 'tr' }, cells);
@@ -2329,9 +2331,12 @@ return view.extend({
 			{key:'proto', label:_('Proto')}, {key:'dst', label:_('Dst IP')},
 			{key:'host', label:_('Hostname')}, {key:'port', label:_('Port')},
 			{key:'service', label:_('Service')}, {key:'bytes', label:_('Bytes')},
-			{key:'state', label:_('State')}
+			{key:'state', label:_('State')}, {key:'oif', label:_('Iface')}
 		];
-		var savedConnHidden = opts.connHiddenCols || {};
+		// 'oif' (egress interface) is only populated for policy-routed (mwan3)
+		// connections, so hide it by default; users on such setups enable it
+		// via the column chip.
+		var savedConnHidden = opts.connHiddenCols || { oif: true };
 		self._connHiddenCols = savedConnHidden;
 		var connColChipsContainer = E('div', {'class':'tc-chips-wrap'});
 		connColDefs.forEach(function(ct) {

--- a/luci-app-trafficctl/root/usr/local/bin/trafficctl-device.sh
+++ b/luci-app-trafficctl/root/usr/local/bin/trafficctl-device.sh
@@ -233,8 +233,37 @@ CW=$(echo "$META_LINE" | awk '{print $8}')
 [ -z "$CW" ] && CW=0
 
 # Build connections JSON array
-CONNS_OUT=$(echo "$CONNTRACK_DATA" | awk -v ip="$IP" -v pf="$PROTO_FILTER" '
-BEGIN { n=0 }
+# Resolve egress interface per destination for policy-routed connections
+# (mwan3 etc.). Only connections carrying a NON-zero conntrack mark are
+# resolved: `ip route get <dst> mark <mark>` honours the fwmark ip-rules, so it
+# reports the WAN that mwan3 actually selected. mark=0 connections (no policy
+# routing, e.g. plain single-WAN or podkop) are left blank instead of showing a
+# misleading main-table egress.
+OIF_MAP="/tmp/trafficctl_oif_$$"
+: > "$OIF_MAP"
+if command -v ip >/dev/null 2>&1; then
+    echo "$CONNTRACK_DATA" | awk -v ip="$IP" '
+    { dst=""; mark="0"; sk="src=" ip; seen=0; got=0
+      for (i=1; i<=NF; i++) {
+          if ($i==sk && !seen) { seen=1; continue }
+          if (seen && !got && index($i,"dst=")==1) { dst=substr($i,5); got=1 }
+          if (index($i,"mark=")==1) mark=substr($i,6)
+      }
+      if (dst!="" && dst!=ip && mark!="0" && mark!="") print dst, mark
+    }' | sort -u | while read -r dip dmark; do
+        [ -n "$dip" ] || continue
+        dev=$(ip route get "$dip" mark "$dmark" 2>/dev/null | grep -oE 'dev [^ ]+' | head -1 | cut -d' ' -f2)
+        case "$dev" in lo|"") continue ;; esac
+        echo "$dip $dev" >> "$OIF_MAP"
+    done
+fi
+
+CONNS_OUT=$(echo "$CONNTRACK_DATA" | awk -v ip="$IP" -v pf="$PROTO_FILTER" -v oifmap="$OIF_MAP" '
+BEGIN {
+    n=0
+    while ((getline line < oifmap) > 0) { split(line, p, " "); oifdev[p[1]] = p[2] }
+    close(oifmap)
+}
 {
     proto=""
     for (i=1; i<=NF; i++) {
@@ -275,11 +304,14 @@ BEGIN { n=0 }
     else if (dport == "993") svc="imaps"
     else if (dport == "8080") svc="http-alt"
 
+    oif = ""
+    if (dst in oifdev) oif = oifdev[dst]
     if (n > 0) printf ","
-    printf "{\"proto\":\"%s\",\"dst\":\"%s\",\"host\":\"\",\"port\":%s,\"service\":\"%s\",\"bytes\":%d,\"state\":\"%s\"}", proto, dst, dport, svc, bytes, state
+    printf "{\"proto\":\"%s\",\"dst\":\"%s\",\"host\":\"\",\"port\":%s,\"service\":\"%s\",\"bytes\":%d,\"state\":\"%s\",\"oif\":\"%s\"}", proto, dst, dport, svc, bytes, state, oif
     n++
 }
 ')
+rm -f "$OIF_MAP"
 
 # Optionally resolve DNS for connection destinations
 if [ "$DO_RDNS" = "1" ]; then


### PR DESCRIPTION
Closes #10. Adds a per-connection **egress interface** to the device view — the "which WAN is this connection using" request from @the-e3n.

## How
For each connection, capture the conntrack fwmark and resolve the egress device via `ip route get <dst> mark <mark>`, which honours the policy-routing `ip rule`s (so it reports the WAN mwan3 actually chose).

**Only non-zero-mark connections are resolved.** That's exactly the case where the router restores the routing mark into the connmark — mwan3 does this, and @the-e3n confirmed non-zero marks (`mark=256/512/16128`) on their 3-WAN box. Connections with `mark=0` (plain single-WAN, or policy routing that doesn't restore the connmark, e.g. podkop) are left blank, so we never show a misleading main-table egress. This is what made a generic version impossible earlier — it's now correct specifically where it can be.

## Changes
- **device.sh** — resolve `dst → interface` for non-zero-mark connections; add `"oif"` to each connection object.
- **status.js** — optional **"Iface"** column in the per-device connections table, **hidden by default** (toggle via the column chips); only meaningful on policy-routed setups.
- **docs/API.md** — document `oif` and its semantics.

## Verified
`dash -n` + `shellcheck -x -e SC1091 -S warning` clean on device.sh; `eslint --max-warnings 0` clean on the frontend.

Credit to @the-e3n for the conntrack-mark data + working PoC in the issue thread.