### PR TITLE
fix(ui): keep the device view live instead of freezing on selection

### DIFF
--- a/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.js
+++ b/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.js
@@ -1264,6 +1264,8 @@ return view.extend({
 	_shapeMap:     {},
 	_speedEwma:    {},
 	_speedEwmaUp:  {},
+	_deviceTimer:  null,
+	_pollMode:     null,
 	_rdnsCache:    {},
 	_sortCol:    'bytes',
 	_sortDir:    'desc',
@@ -1865,7 +1867,9 @@ return view.extend({
 
 		function pollBytes() {
 			if (document.hidden) return;
-			if (!isAllMode()) return;
+			// Runs in BOTH modes: byte counters are per-device, and the device
+			// view's speed graph is fed from this history. Only the summary-table
+			// repaint below is all-devices-specific.
 			callBytes().then(function(data) {
 				if (!Array.isArray(data)) return;
 				var now = Date.now();
@@ -1959,10 +1963,12 @@ return view.extend({
 						time: now
 					};
 				});
-				if (self._sumCol === '_speed') {
-					runAll();
-				} else {
-					updateSpeedCells();
+				if (isAllMode()) {
+					if (self._sumCol === '_speed') {
+						runAll();
+					} else {
+						updateSpeedCells();
+					}
 				}
 				updateDeviceGraph();
 			}).catch(function(){});
@@ -2258,13 +2264,20 @@ return view.extend({
 			var o = loadOpts(); o.lastIp = ip; saveOpts(o);
 			updateUrlParams(o);
 			updateModeUI();
+			// Switching between all-devices and a single device changes which
+			// timers should be running, so tear them down and let the branch
+			// below start the right set.
+			var mode = (ip === '__all__') ? 'all' : 'device';
+			if (self._pollMode !== mode) {
+				self._pollMode = mode;
+				self._stopBytesPoll();
+			}
 			if (ip === '__all__') {
 				deviceGraphDiv.classList.add('tc-hidden');
 				runAll();
 			} else {
-				self._stopBytesPoll();
-				pollDrops();
 				runSingle(ip);
+				self._startBytesPoll();
 			}
 			updateExtendedStats();
 		}
@@ -2316,15 +2329,26 @@ return view.extend({
 			self._dropTimer = setInterval(pollDrops, 5000);
 			pollShapeStats();
 			self._shapeTimer = setInterval(pollShapeStats, 5000);
+			// Device view: keep the connection table live as well, instead of
+			// freezing until the user manually refreshes. Floored at 3s because
+			// this re-reads conntrack for the device on every tick.
+			if (!isAllMode()) {
+				self._deviceTimer = setInterval(function() {
+					if (document.hidden) return;
+					var ip = searchSelect.getValue();
+					if (ip && ip !== '__all__') runSingle(ip);
+				}, Math.max(pollMs, 3000));
+			}
 		};
 		this._stopBytesPoll = function() {
-			if (self._bytesTimer) { clearInterval(self._bytesTimer); self._bytesTimer = null; }
-			if (self._dropTimer)  { clearInterval(self._dropTimer);  self._dropTimer  = null; }
-			if (self._shapeTimer) { clearInterval(self._shapeTimer); self._shapeTimer = null; }
+			if (self._bytesTimer)  { clearInterval(self._bytesTimer);  self._bytesTimer  = null; }
+			if (self._dropTimer)   { clearInterval(self._dropTimer);   self._dropTimer   = null; }
+			if (self._shapeTimer)  { clearInterval(self._shapeTimer);  self._shapeTimer  = null; }
+			if (self._deviceTimer) { clearInterval(self._deviceTimer); self._deviceTimer = null; }
 		};
 		this._restartBytesPoll = function() {
 			self._stopBytesPoll();
-			if (isAllMode()) self._startBytesPoll();
+			self._startBytesPoll();
 		};
 
 		this._setupTimer();
@@ -2892,7 +2916,7 @@ return view.extend({
 		]);
 		var tableSection = mkCollapsible(_('Table & Speed'), E('div', {'class':'tc-table-speed-inner'}, [
 			E('div', {'class':'tc-table-speed-row'}, [
-				E('span', {'data-tip':_('Polling interval for per-device speed graph')}, [mkLabel(_('Poll')+':'), pollIntervalPick.el]),
+				E('span', {'data-tip':_('How often live data is polled: speeds, graphs, drop/backlog counters, and the connection table in device view')}, [mkLabel(_('Poll')+':'), pollIntervalPick.el]),
 				sep(),
 				E('span', {'data-tip':_('Time window for speed averaging')}, [mkLabel(_('Window')+':'), avgWindowPick.el]),
 				sep(),


### PR DESCRIPTION
Addresses **#26 items 5 and 6** (@the-e3n: *"Once i click on any device the tables stops refreshing"* / *"The filters in device views are not updating the table"*).

## The bug
Selecting a device killed all polling — `runQuery()` called `_stopBytesPoll()`, and `pollBytes()` additionally bailed with `if (!isAllMode()) return;`. So in device view the speed, drop and backlog figures **and** the connection table all froze until a manual refresh.

That early-return also made the per-device speed graph dead code: `updateDeviceGraph()` exists *only* for single-device mode, but it's called from the tail of `pollBytes()` — which refused to run in that mode. So the device graph has never updated live.

## The fix
- `pollBytes()` now runs in **both** modes; only the summary-table repaint (`runAll`/`updateSpeedCells`) is gated on all-devices mode. `pollDrops()` and `pollShapeStats()` already guarded their own cell updates, so they were safe to run.
- Device view starts the poll, and additionally refreshes the connection table on its own timer — **floored at 3s**, since each tick re-reads conntrack for that device (rDNS is unaffected: `_rdnsCache` means repeat ticks only resolve genuinely new destinations).
- `runQuery()` tears the timers down when the mode changes, so the device-table timer can't leak into all-devices mode and vice versa. `_stopBytesPoll()` clears it, and that's already called on view destroy — no timer leak.
- The **Poll** tooltip claimed it only affected the per-device speed graph; it drives every live update, so it now says so (the *"should be mentioned here"* part of item 1).

## Status of the rest of #26
| Item | Status |
|---|---|
| 1 — speed only refreshes when sorted by DL Speed | **Fixed in #34** — it was the dead `td[data-…]` selectors; the `_speed` sort path did a full `runAll()` rebuild, which is why that one column appeared to work |
| 4 — custom polling interval | **Already exists** as the "Poll" chip (2/3/5/10s) |
| 5, 6 | **This PR** |
| 2 — browser history / back gesture | not addressed (uses `replaceState`; needs a `pushState` + `popstate` design decision) |
| 3 — Bytes/TCP/UDP not cumulative | not addressed — those come from live conntrack, so they reflect *currently tracked* connections, not a lifetime total. Making them cumulative needs persistent accumulation (à la the nft counters in `bytes-nft.sh`) |
| 7 — global/bmon-style speed overview | not addressed (new feature) |

## Verified
`eslint --max-warnings 0` clean; `node --check` parses.