### PR TITLE
feat(wifi): support allow-mode (whitelist) ACLs and stop clobbering them

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -141,7 +141,7 @@ In practice, both achieve the same result (excess packets are dropped), but the 
 
 ### WiFi MAC Filtering
 
-11. **Requires deny mode** -- The package sets `macfilter=deny` on all wifi-iface sections. If you are using `macfilter=allow` (whitelist mode), this will conflict.
+11. **Both ACL modes supported** -- The package adapts to whichever `macfilter` policy each wifi-iface already uses and never changes it. On a `deny` (blacklist) radio, blocking adds the MAC to `maclist`; on an `allow` (whitelist) radio, blocking *removes* it, since there being listed is what grants access. Only when a radio has no `macfilter` set at all does the package create one, using `deny`. Mixed-mode setups are handled per radio: a device counts as wifi-blocked if it is blocked on any radio.
 
 12. **WiFi deauth** -- MAC filter changes are applied via `hostapd_cli deny_acl` + `deauthenticate`. Only the target client is disconnected; other clients are unaffected. Disconnection is near-instant (no wifi reload).
 

--- a/luci-app-trafficctl/root/usr/local/bin/trafficctl-device.sh
+++ b/luci-app-trafficctl/root/usr/local/bin/trafficctl-device.sh
@@ -133,9 +133,14 @@ if [ -n "$MAC" ]; then
     IFACES=$(tctl_get_wifi_interfaces)
     for iface in $IFACES; do
         maclist=$(uci -q get "wireless.${iface}.maclist")
-        if echo "$maclist" | grep -qi "$MAC"; then
-            WIFI_BLOCKED=true
-            break
+        listed=0
+        echo "$maclist" | grep -qi "$MAC" && listed=1
+        # Being listed means the opposite thing per policy: on a deny radio a
+        # listed MAC is blocked, on an allow (whitelist) radio an UNlisted one is.
+        if [ "$(tctl_get_wifi_filter_mode "$iface")" = "allow" ]; then
+            [ "$listed" = "0" ] && { WIFI_BLOCKED=true; break; }
+        else
+            [ "$listed" = "1" ] && { WIFI_BLOCKED=true; break; }
         fi
     done
 fi

--- a/luci-app-trafficctl/root/usr/local/bin/trafficctl-fw.sh
+++ b/luci-app-trafficctl/root/usr/local/bin/trafficctl-fw.sh
@@ -169,6 +169,45 @@ tctl_get_hostapd_ifaces() {
 }
 
 # Add MAC to hostapd deny ACL at runtime + deauth the client (no wifi reload)
+# Which ACL policy a wifi-iface uses: "allow" (whitelist — only listed MACs may
+# associate) or "deny" (blacklist — listed MACs are rejected). Anything else,
+# including unset, means no filtering is configured yet, reported as "deny"
+# because that is the mode we create on demand.
+tctl_get_wifi_filter_mode() {
+    local iface="$1" mode
+    mode=$(uci -q get "wireless.${iface}.macfilter" 2>/dev/null)
+    [ "$mode" = "allow" ] && echo "allow" || echo "deny"
+}
+
+# Block a MAC at runtime. In deny mode that means adding it to the deny ACL; in
+# allow (whitelist) mode it means dropping it from the accept ACL. Either way
+# the client is deauthenticated so the change takes effect immediately.
+tctl_hostapd_block_mac() {
+    local mac="$1" mode="$2"
+    local iface
+    for iface in $(tctl_get_hostapd_ifaces); do
+        if [ "$mode" = "allow" ]; then
+            hostapd_cli -i "$iface" accept_acl DEL_MAC "$mac" 2>/dev/null
+        else
+            hostapd_cli -i "$iface" deny_acl ADD_MAC "$mac" 2>/dev/null
+        fi
+        hostapd_cli -i "$iface" deauthenticate "$mac" 2>/dev/null
+    done
+}
+
+# Unblock a MAC at runtime — the inverse of tctl_hostapd_block_mac.
+tctl_hostapd_unblock_mac() {
+    local mac="$1" mode="$2"
+    local iface
+    for iface in $(tctl_get_hostapd_ifaces); do
+        if [ "$mode" = "allow" ]; then
+            hostapd_cli -i "$iface" accept_acl ADD_MAC "$mac" 2>/dev/null
+        else
+            hostapd_cli -i "$iface" deny_acl DEL_MAC "$mac" 2>/dev/null
+        fi
+    done
+}
+
 tctl_hostapd_deny_mac() {
     local mac="$1"
     local iface

--- a/luci-app-trafficctl/root/usr/local/bin/trafficctl-macfilter-add.sh
+++ b/luci-app-trafficctl/root/usr/local/bin/trafficctl-macfilter-add.sh
@@ -44,24 +44,42 @@ if [ -z "$IFACES" ]; then
 fi
 
 CHANGED=0
+MODE="deny"
 for iface in $IFACES; do
-    current_filter=$(uci -q get "wireless.${iface}.macfilter")
-    if [ "$current_filter" != "deny" ]; then
-        uci set "wireless.${iface}.macfilter=deny"
-        CHANGED=1
-    fi
+    # Respect the ACL policy the administrator configured. Forcing macfilter to
+    # "deny" here used to invert an existing whitelist: the curated allow-list
+    # would start being read as a block-list, letting in every device it was
+    # meant to keep out and banning every device it listed.
+    iface_mode=$(tctl_get_wifi_filter_mode "$iface")
+    [ "$iface_mode" = "allow" ] && MODE="allow"
 
     existing=$(uci -q get "wireless.${iface}.maclist")
-    echo "$existing" | grep -qi "$MAC" && continue
+    listed=0
+    echo "$existing" | grep -qi "$MAC" && listed=1
 
-    uci add_list "wireless.${iface}.maclist=$MAC"
-    CHANGED=1
+    if [ "$iface_mode" = "allow" ]; then
+        # Whitelist: blocking means dropping the MAC from the allow-list.
+        if [ "$listed" = "1" ]; then
+            uci del_list "wireless.${iface}.maclist=$MAC"
+            CHANGED=1
+        fi
+    else
+        # Blacklist: blocking means adding the MAC, creating the list if needed.
+        if [ -z "$(uci -q get "wireless.${iface}.macfilter")" ]; then
+            uci set "wireless.${iface}.macfilter=deny"
+            CHANGED=1
+        fi
+        if [ "$listed" = "0" ]; then
+            uci add_list "wireless.${iface}.maclist=$MAC"
+            CHANGED=1
+        fi
+    fi
 done
 
 if [ "$CHANGED" = "1" ]; then
     uci commit wireless
-    # Apply at runtime: add to deny ACL + deauth this client only
-    tctl_hostapd_deny_mac "$MAC"
+    # Apply at runtime and deauth just this client — no wifi reload.
+    tctl_hostapd_block_mac "$MAC" "$MODE"
 fi
 
 tctl_log "wifi_block" "$IP" "MAC=$MAC" "${TCTL_VIA:-cli}" "${TCTL_SRC:-local}"

--- a/luci-app-trafficctl/root/usr/local/bin/trafficctl-macfilter-remove.sh
+++ b/luci-app-trafficctl/root/usr/local/bin/trafficctl-macfilter-remove.sh
@@ -44,18 +44,34 @@ if [ -z "$IFACES" ]; then
 fi
 
 CHANGED=0
+MODE="deny"
 for iface in $IFACES; do
+    iface_mode=$(tctl_get_wifi_filter_mode "$iface")
+    [ "$iface_mode" = "allow" ] && MODE="allow"
+
     existing=$(uci -q get "wireless.${iface}.maclist")
-    if echo "$existing" | grep -qi "$MAC"; then
-        uci del_list "wireless.${iface}.maclist=$MAC"
-        CHANGED=1
+    listed=0
+    echo "$existing" | grep -qi "$MAC" && listed=1
+
+    if [ "$iface_mode" = "allow" ]; then
+        # Whitelist: unblocking means putting the MAC back on the allow-list.
+        if [ "$listed" = "0" ]; then
+            uci add_list "wireless.${iface}.maclist=$MAC"
+            CHANGED=1
+        fi
+    else
+        # Blacklist: unblocking means removing the MAC from the block-list.
+        if [ "$listed" = "1" ]; then
+            uci del_list "wireless.${iface}.maclist=$MAC"
+            CHANGED=1
+        fi
     fi
 done
 
 if [ "$CHANGED" = "1" ]; then
     uci commit wireless
-    # Remove from runtime deny ACL — client can reassociate immediately
-    tctl_hostapd_allow_mac "$MAC"
+    # Update the runtime ACL — the client can reassociate immediately.
+    tctl_hostapd_unblock_mac "$MAC" "$MODE"
 fi
 
 tctl_log "wifi_unblock" "$IP" "MAC=$MAC" "${TCTL_VIA:-cli}" "${TCTL_SRC:-local}"

--- a/luci-app-trafficctl/root/usr/local/bin/trafficctl-summary.sh
+++ b/luci-app-trafficctl/root/usr/local/bin/trafficctl-summary.sh
@@ -177,8 +177,24 @@ if command -v tc >/dev/null 2>&1; then
     }')
 fi
 
-# All wifi maclists concatenated (a device is wifi-blocked if its MAC is in any)
-WIFI_MACLISTS=$(uci -q show wireless 2>/dev/null | grep '\.maclist=')
+# Wifi ACL state, split by policy, because "listed" means opposite things in the
+# two modes: on a deny (blacklist) radio a listed MAC is blocked, on an allow
+# (whitelist) radio a listed MAC is the only kind permitted. Collected once here
+# and matched fork-free per device below.
+WIFI_DENY_MACS=""
+WIFI_ALLOW_MACS=""
+WIFI_HAS_ALLOW=0
+for _wif in $(tctl_get_wifi_interfaces); do
+    _wlist=$(uci -q get "wireless.${_wif}.maclist" 2>/dev/null)
+    if [ "$(tctl_get_wifi_filter_mode "$_wif")" = "allow" ]; then
+        WIFI_HAS_ALLOW=1
+        WIFI_ALLOW_MACS="$WIFI_ALLOW_MACS $_wlist"
+    else
+        WIFI_DENY_MACS="$WIFI_DENY_MACS $_wlist"
+    fi
+done
+WIFI_DENY_MACS=" $(echo "$WIFI_DENY_MACS" | tr 'A-F' 'a-f') "
+WIFI_ALLOW_MACS=" $(echo "$WIFI_ALLOW_MACS" | tr 'A-F' 'a-f') "
 
 WIFI_STATIONS=$(get_wifi_stations)
 BRIDGE_MACS=$(get_bridge_macs)
@@ -239,7 +255,16 @@ lookup_shape_kbit() {
 lookup_wifi_blocked() {
     local mac="$1"
     [ -z "$mac" ] && { echo 0; return; }
-    echo "$WIFI_MACLISTS" | grep -qi "$mac" && echo 1 || echo 0
+    # Listed on a deny radio -> blocked there.
+    case "$WIFI_DENY_MACS" in *" $mac "*) echo 1; return ;; esac
+    # Absent from a whitelist radio -> cannot associate there, so also blocked.
+    if [ "$WIFI_HAS_ALLOW" = "1" ]; then
+        case "$WIFI_ALLOW_MACS" in
+            *" $mac "*) ;;
+            *) echo 1; return ;;
+        esac
+    fi
+    echo 0
 }
 
 # ── Emit JSON ──────────────────────────────────────────────────────────────

--- a/tests/test_fw.sh
+++ b/tests/test_fw.sh
@@ -85,6 +85,25 @@ assert_eq "offload_mode: hardware (no counter flag in flowtable)" \
 assert_eq "offload_mode: hardware-counter (counter flag present)" \
     "hardware-counter" "$(_offload_mode 0 1 "flowtable ft { flags { offload, counter }; devices = { eth0 }; }")"
 
+# --- tctl_get_wifi_filter_mode ---
+# Only an explicit "allow" is a whitelist; everything else (including unset, and
+# any unexpected value) must report "deny", because that is the policy the
+# package creates on demand. Getting this backwards would invert an
+# administrator's ACL — see the wifi allow-mode fix.
+
+_filter_mode() {
+    # $1 = value uci returns for wireless.<iface>.macfilter. Held in a variable
+    # because the stub's own $1 is the "-q" flag, not the configured value.
+    _MACFILTER="$1"
+    uci() { echo "$_MACFILTER"; }
+    tctl_get_wifi_filter_mode wifiX
+}
+
+assert_eq "wifi filter mode: allow" "allow" "$(_filter_mode allow)"
+assert_eq "wifi filter mode: deny" "deny" "$(_filter_mode deny)"
+assert_eq "wifi filter mode: unset defaults to deny" "deny" "$(_filter_mode '')"
+assert_eq "wifi filter mode: unknown value defaults to deny" "deny" "$(_filter_mode bogus)"
+
 # --- Results ---
 
 printf "\n%d passed, %d failed\n" "$PASS" "$FAIL"


### PR DESCRIPTION
Closes #31 (forum request for MAC-based whitelisting) — and fixes a security bug found while implementing it.

## ⚠️ The bug
Blocking a device forced `macfilter=deny` on **every** wifi-iface and appended the MAC to `maclist`:

```sh
current_filter=$(uci -q get "wireless.${iface}.macfilter")
if [ "$current_filter" != "deny" ]; then
    uci set "wireless.${iface}.macfilter=deny"   # <-- clobbers an existing whitelist
```

On a router already running `macfilter=allow`, one click of "block this device" **inverted the administrator's security policy**: the curated whitelist stayed in `maclist` but was now interpreted as a *block*-list — so every device the whitelist existed to keep out could suddenly join, and every device it listed was banned. `docs/COMPATIBILITY.md` even documented the conflict, but the code overwrote the setting rather than respecting it.

## The fix
Adapt to whichever policy each radio already uses, and never change it:

| radio policy | block | unblock |
|---|---|---|
| `deny` (blacklist) | add MAC to `maclist` | remove it |
| `allow` (whitelist) | **remove** MAC from `maclist` | add it back |
| unset | create `deny` on demand (unchanged behaviour) | — |

Runtime ACLs follow the same split (`deny_acl` vs `accept_acl`), and blocking still deauthenticates only the target client — no wifi reload.

Detection is inverted to match, since *listed* means opposite things per policy:
- `summary.sh` collects the two policies' maclists separately **once**, then matches fork-free per device — the hot path I optimised earlier gets no slower (it actually drops 2 forks per device).
- `device.sh` checks per radio.
- A device counts as blocked if it is blocked on **any** radio, so mixed-mode setups stay correct.

This is why I implemented it as policy-awareness rather than a mode toggle in our own config: it respects what the admin already configured instead of adding a second, competing source of truth.

## Tests
Added unit tests for `tctl_get_wifi_filter_mode`, including that unset and unexpected values fall back to `deny` — getting that backwards is exactly what would flip an ACL. **23/23 pass.**

Gates: `dash -n`, `shellcheck -x -e SC1091 -S warning`, and the repo bashism checker all clean on all five changed scripts.

Docs: the "Requires deny mode" limitation in `COMPATIBILITY.md` is replaced with the actual behaviour.