### PR TITLE
refactor: read UCI config via config_load/config_get

### DIFF
--- a/luci-app-trafficctl/root/usr/local/bin/trafficctl-telegram.sh
+++ b/luci-app-trafficctl/root/usr/local/bin/trafficctl-telegram.sh
@@ -4,6 +4,8 @@
 # Runs under procd. Uses curl + jsonfilter to talk to Telegram Bot API.
 # Only responds to the authorized chat_id configured in UCI.
 
+. /lib/functions.sh
+
 SCRIPTS="/usr/local/bin"
 KNOWN_FILE="/etc/trafficctl/telegram_known.json"
 OFFSET_FILE="/tmp/trafficctl_tg_offset"
@@ -31,18 +33,19 @@ TG_BTN_SHAPE=1
 # ── config ──────────────────────────────────────────────────────────────────
 
 load_config() {
-	TG_ENABLED=$(uci -q get trafficctl.telegram.enabled || echo 0)
-	TG_TOKEN=$(uci -q get trafficctl.telegram.bot_token)
-	TG_CHAT_ID=$(uci -q get trafficctl.telegram.chat_id)
-	TG_POLL=$(uci -q get trafficctl.telegram.poll_interval || echo 3)
-	TG_NOTIFY_NEW=$(uci -q get trafficctl.telegram.notify_new_device || echo 1)
-	TG_NOTIFY_KNOWN=$(uci -q get trafficctl.telegram.notify_known_device || echo 0)
-	TG_CONTROL=$(uci -q get trafficctl.telegram.control_enabled || echo 1)
-	TG_NOTIFY_TEMPLATE=$(uci -q get trafficctl.telegram.notify_template)
-	TG_BTN_INET=$(uci -q get trafficctl.telegram.btn_block_inet || echo 1)
-	TG_BTN_WIFI=$(uci -q get trafficctl.telegram.btn_block_wifi || echo 1)
-	TG_BTN_LIMIT=$(uci -q get trafficctl.telegram.btn_limiter || echo 1)
-	TG_BTN_SHAPE=$(uci -q get trafficctl.telegram.btn_shaper || echo 1)
+	config_load trafficctl
+	config_get TG_ENABLED telegram enabled 0
+	config_get TG_TOKEN telegram bot_token ""
+	config_get TG_CHAT_ID telegram chat_id ""
+	config_get TG_POLL telegram poll_interval 3
+	config_get TG_NOTIFY_NEW telegram notify_new_device 1
+	config_get TG_NOTIFY_KNOWN telegram notify_known_device 0
+	config_get TG_CONTROL telegram control_enabled 1
+	config_get TG_NOTIFY_TEMPLATE telegram notify_template ""
+	config_get TG_BTN_INET telegram btn_block_inet 1
+	config_get TG_BTN_WIFI telegram btn_block_wifi 1
+	config_get TG_BTN_LIMIT telegram btn_limiter 1
+	config_get TG_BTN_SHAPE telegram btn_shaper 1
 	[ "$TG_POLL" -ge 2 ] 2>/dev/null || TG_POLL=3
 }
 

--- a/tests/test_telegram_e2e.sh
+++ b/tests/test_telegram_e2e.sh
@@ -71,6 +71,28 @@ setup_env() {
 network_get_ipaddr() { eval "$1='198.51.100.42'"; }
 MOCK
 
+    # functions.sh stub — minimal config_load/config_get(_bool) that reads
+    # through the mocked `uci get` below (real /lib/functions.sh calls
+    # `uci export`, which this test's uci mock doesn't implement; this
+    # shim keeps the same external interface load_config() relies on).
+    cat > "$MOCKDIR/lib/functions.sh" <<'MOCK'
+__CONFIG_PACKAGE=""
+config_load() { __CONFIG_PACKAGE="$1"; }
+config_get() {
+    local __var="$1" __section="$2" __option="$3" __default="$4" __val
+    __val=$(uci -q get "${__CONFIG_PACKAGE}.${__section}.${__option}" 2>/dev/null)
+    eval "$__var=\"\${__val:-\$__default}\""
+}
+config_get_bool() {
+    local __var="$1" __section="$2" __option="$3" __default="$4" __val
+    __val=$(uci -q get "${__CONFIG_PACKAGE}.${__section}.${__option}" 2>/dev/null)
+    case "${__val:-$__default}" in
+        1|on|true|yes|enabled) eval "$__var=1" ;;
+        *) eval "$__var=0" ;;
+    esac
+}
+MOCK
+
     # uci mock — realistic chat_id and token format (test values, not real)
     cat > "$MOCKBIN/uci" <<'MOCK'
 #!/bin/sh
@@ -333,6 +355,7 @@ run_bot_once() {
         -e 's|/proc/loadavg|'"$MOCKDIR"'/proc/loadavg|g' \
         -e 's|/proc/net/nf_conntrack|'"$MOCKDIR"'/proc/nf_conntrack|g' \
         -e 's|\. /lib/functions/network.sh|. '"$MOCKDIR"'/lib/functions/network.sh|' \
+        -e 's|\. /lib/functions.sh|. '"$MOCKDIR"'/lib/functions.sh|' \
         -e 's|/tmp/trafficctl_tg_seen.tmp|'"$MOCKDIR"'/tmp/seen.tmp|' \
         -e 's|/tmp/trafficctl_tg_cur.tmp|'"$MOCKDIR"'/tmp/cur.tmp|' \
         -e 's|/tmp/.trafficctl_known.lock|'"$MOCKDIR"'/tmp/.lock|g' \


### PR DESCRIPTION
## What changed

`load_config()` in `trafficctl-telegram.sh` read 12 UCI options with sequential `uci -q get trafficctl.telegram.X || echo <default>` calls, each forking a separate `uci` process. It runs both at bot startup and every ~60s in the main poll loop.

Switched to the idiomatic OpenWrt pattern suggested by @stangri on the forum: source `/lib/functions.sh` once, then `config_load trafficctl` + `config_get VAR telegram option default` per field. `config_load` does a single `uci export` internally, so the per-call cost drops from up to 12 forks to 1.

- `luci-app-trafficctl/root/usr/local/bin/trafficctl-telegram.sh`: `load_config()` refactored — 12 `uci -q get` calls replaced with `config_load` + 12 `config_get` calls.
- `tests/test_telegram_e2e.sh`: added a minimal `/lib/functions.sh` mock (`config_load`/`config_get`/`config_get_bool` backed by the existing mocked `uci get`) and redirected the script's new `. /lib/functions.sh` to it, the same way the existing `network.sh` stub is redirected — needed because this test runs the real bot script against a `uci` mock that only implements `get`, not `export`.

## Behaviour/defaults unchanged

- `config_get`'s `${VAR:-default}` fallback matches the previous `uci get || echo default` fallback for every option here.
- All downstream comparisons (`= "1"`, `!= "1"`, `-ge 2`) still run against the same raw string values as before.
- Used `config_get` (not `config_get_bool`) throughout, since the existing code compares literal `"1"`/`"0"` strings and `config_get_bool`'s truthy-word mapping isn't guaranteed identical — per the correctness notes for this refactor.

## Scope decisions

- **`luci.trafficctl` (rpcd backend)**: left alone. It prints raw JSON to stdout for ubus, and this environment can't verify that sourcing `/lib/functions.sh` there wouldn't leak anything onto stdout and corrupt that output. Its `telegram_config_get` case has the same 12-option pattern and would benefit, but the risk isn't verifiable here.
- **`trafficctl-fw.sh`**: left alone. Its UCI reads are single reads scattered across separate functions, not 3+ in a row, so converting them wouldn't reduce real repetition.

## Verification

```
dash -n <changed scripts>                                    → OK
shellcheck -x -e SC1091 -S warning <changed scripts>          → no warnings
grep -nE '^[[:space:]]*[a-zA-Z_]+[[:space:]]*=[[:space:]]*\(' → no bashisms
sh tests/test_telegram_mock.sh   → 36 passed, 1 failed (pre-existing macOS
                                     backslash-escaping failure, unrelated)
sh tests/test_fw.sh              → 19 passed, 0 failed
```

Also manually verified the new `load_config()` against a standalone mocked `uci`/`/lib/functions.sh` (both with values set and with everything unset) — all 12 fields resolve to the exact same values/defaults as the old `uci -q get || echo default` code did.

`tests/test_telegram_e2e.sh` (which runs the real bot end-to-end) already fails on unmodified `main` in this sandbox because `timeout` isn't available on macOS — pre-existing environment gap, not something this PR introduces or needs to fix; it should run fine in the Linux CI runner.

Closes #29. Suggested by @stangri on the OpenWrt forum: "The OpenWrt way is config_load + config_get/config_get_bool with default values."

🤖 Generated with [Claude Code](https://claude.com/claude-code)