### PR TITLE
fix(ui): split speed into separate sortable DL and UL columns

### DIFF
--- a/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.css
+++ b/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.css
@@ -659,5 +659,3 @@
 }
 
 /* Split down/up speed cell */
-.tc-spd-dn { font-size: 11px; line-height: 1.25; }
-.tc-spd-up { font-size: 10px; line-height: 1.25; color: var(--tc-muted); }

--- a/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.js
+++ b/luci-app-trafficctl/htdocs/luci-static/resources/view/trafficctl/status.js
@@ -254,10 +254,10 @@ function renderSpeedCell(cell, sd) {
 		cell.appendChild(document.createTextNode('—'));
 		return;
 	}
-	var active = (sd.current > 1024) || (sd.up > 1024);
-	cell.className = 'td tc-right tc-mono ' + (active ? 'tc-speed-active' : 'tc-speed-idle');
-	cell.appendChild(E('div', { 'class': 'tc-spd-dn' }, '↓ ' + fmtSpeed(sd.current)));
-	cell.appendChild(E('div', { 'class': 'tc-spd-up' }, '↑ ' + fmtSpeed(sd.up || 0)));
+	// Download only — upload has its own sortable "UL Speed" column, so showing
+	// it here too would duplicate it and make neither column sortable on its own.
+	cell.className = 'td tc-right tc-mono ' + (sd.current > 1024 ? 'tc-speed-active' : 'tc-speed-idle');
+	cell.appendChild(document.createTextNode(fmtSpeed(sd.current)));
 }
 
 function escHtml(s) {


### PR DESCRIPTION
Follow-up to the #27 merge, which left upload speed displayed twice.

After merging, the **DL Speed** cell rendered a combined `↓ x / ↑ y` pair *and* the separate **UL Speed** column (from #34) rendered upload again.

Beyond the visual duplication, packing both directions into one cell means **neither can be sorted independently** — that column sorts by `_speed` only.

## Change
- `renderSpeedCell()` renders **download only**
- the **UL Speed** column carries upload
- both are `num:true` and backed by row fields (`_speed`, `_speed_up`), so each sorts on its own
- both render as plain values — the column headers already say which direction is which, so the arrows were redundant
- drops the now-unused `.tc-spd-dn`/`.tc-spd-up` CSS rules

Verified: `eslint --max-warnings 0` exit 0, `node --check` parses, CSS braces balance.