### PR TITLE
docs: record v1.13.0, trim changelog boilerplate, add upgrade guide to releases

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -5,6 +5,14 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Two merges landing seconds apart each start a release job; they then race
+# on `git push origin main <tag>`, and the loser dies with "failed to push
+# some refs" after having already tagged. Serialise them, and never cancel
+# a run mid-release — a half-finished release leaves a tag with no artifacts.
+concurrency:
+  group: auto-release
+  cancel-in-progress: false
+
 permissions:
   contents: write
 
@@ -259,6 +267,8 @@ jobs:
           git add luci-app-trafficctl/Makefile CHANGELOG.md
           git commit -m "chore: bump version to ${{ steps.bump.outputs.new_version }}"
           git tag "${{ steps.bump.outputs.new_tag }}"
+          # main may have advanced while CI ran; rebase rather than fail.
+          git pull --rebase origin main
           git push origin main "${{ steps.bump.outputs.new_tag }}"
 
       - name: Build .ipk (standalone)

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -187,6 +187,31 @@ jobs:
             echo "\`\`\`"
             echo ""
             echo "Other filenames (\`_all.ipk\`, \`_noarch.apk\`, versioned) are the same file."
+            echo ""
+            echo "### Upgrading an existing install"
+            echo ""
+            echo "Install over the current version — both package managers upgrade in"
+            echo "place, so there is no need to remove the old one first."
+            echo ""
+            echo "\`\`\`sh"
+            echo "cd /tmp"
+            echo "# OpenWrt 21.02 - 24.10"
+            echo "wget https://github.com/${{ github.repository }}/releases/latest/download/luci-app-trafficctl.ipk"
+            echo "opkg install /tmp/luci-app-trafficctl.ipk"
+            echo ""
+            echo "# OpenWrt 25.12+ / snapshot"
+            echo "wget https://github.com/${{ github.repository }}/releases/latest/download/luci-app-trafficctl.apk"
+            echo "apk add --allow-untrusted /tmp/luci-app-trafficctl.apk"
+            echo ""
+            echo "# required either way - rpcd caches the backend"
+            echo "/etc/init.d/rpcd restart"
+            echo "# only if the Telegram bot is enabled"
+            echo "/etc/init.d/trafficctl-telegram restart"
+            echo "\`\`\`"
+            echo ""
+            echo "Your settings are kept: \`/etc/config/trafficctl\` is a conffile, so the"
+            echo "package manager preserves it and writes the new defaults alongside as"
+            echo "\`/etc/config/trafficctl-opkg\`, which you can delete."
             echo 'CHANGELOG_EOF'
           } >> "$GITHUB_OUTPUT"
 
@@ -220,6 +245,11 @@ jobs:
               raise SystemExit(0)
           # Drop the generated heading; the version heading replaces it.
           body = re.sub(r"^## What's Changed\s*", '', body).strip()
+          # The release body also carries a download table and install commands.
+          # Useful on the Releases page, pure noise repeated in every changelog
+          # entry — drop that section but keep everything above it.
+          trimmed = re.split(r'\n-{3,}\s*\n+### Download', body)[0].strip()
+          body = trimmed or body
           entry = '## [%s] - %s\n\n%s\n\n---\n\n' % (ver, today, body)
           i = text.find('\n## [')
           text = (text[:i + 1] + entry + text[i + 1:]) if i != -1 else (text.rstrip() + '\n\n' + entry)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,24 +10,7 @@ All notable changes to luci-app-trafficctl since v1.0.0.
 
 ---
 
-### Download
-
-| File | OpenWrt version | Install command |
-|------|----------------|-----------------|
-| `luci-app-trafficctl.ipk` | 21.02 — 24.10 | `opkg install <file>` |
-| `luci-app-trafficctl.apk` | 25.12+ | `apk add --allow-untrusted <file>` |
-
-Stable URL (always points to the latest release):
-```
-wget https://github.com/YusDyr/luci-app-trafficctl/releases/latest/download/luci-app-trafficctl.ipk
-wget https://github.com/YusDyr/luci-app-trafficctl/releases/latest/download/luci-app-trafficctl.apk
-```
-
-Other filenames (`_all.ipk`, `_noarch.apk`, versioned) are the same file.
-
----
-
-## [Unreleased]
+## [1.13.0] — 2026-08-24
 
 ### Features
 
@@ -35,7 +18,16 @@ Other filenames (`_all.ipk`, `_noarch.apk`, versioned) are the same file.
 - **Port Forwards tab** — view and manage DNAT rules from the app. ([#27](https://github.com/YusDyr/luci-app-trafficctl/pull/27))
 - **Routed-subnet monitoring** and improved device naming. ([#27](https://github.com/YusDyr/luci-app-trafficctl/pull/27))
 - **Optional netifyd DPI labels** — per-device application names when the Netify agent is installed. Entirely optional: not a package dependency, and inert when the agent or its socket is absent. ([#27](https://github.com/YusDyr/luci-app-trafficctl/pull/27))
+- **Subnet and whole-network limits** — rate-limit an entire subnet or the whole LAN from the UI, either per-device or as an aggregate. ([#27](https://github.com/YusDyr/luci-app-trafficctl/pull/27))
+- **Download and upload speed shown separately per device**, each in its own sortable column.
 - **Prometheus metrics endpoint** — `/cgi-bin/trafficctl-metrics`, disabled by default, with an optional shared token. ([#27](https://github.com/YusDyr/luci-app-trafficctl/pull/27))
+
+### Bug Fixes
+
+- Per-device speed monitoring no longer stops on kernels where dynamic nftables counter maps are unsupported.
+- The custom rate field no longer closes itself a few seconds after being opened.
+- Netify telemetry is read from the socket sink rather than the agent API socket, and the sample window now covers the aggregator's report interval.
+- Client-controlled device names are escaped in the summary JSON.
 
 Thanks to [@adeelahmad](https://github.com/adeelahmad) for this contribution.
 


### PR DESCRIPTION
Three changelog/release fixes.

**1. v1.13.0 was missing.** It shipped #27 (Prometheus exporter, netifyd DPI, Port Forwards, routed subnets, bidirectional + subnet limits) but predates the automation from #41 — its release job ran the older workflow. Promotes the `Unreleased` section, which already described exactly that work, to `## [1.13.0]` and adds what shipped alongside it.

**2. The automation was writing boilerplate into the changelog.** It fed the whole release body in, so every entry carried the download table and install commands — v1.13.1's entry was 20 lines of which 19 were repeated boilerplate. The release body is now trimmed at `### Download` before it is written to the file (falling back to the untrimmed body if that would leave nothing). The already-written 1.13.1 entry is cleaned up too: 20 lines → 1.

**3. Upgrade instructions added to the release body** (not the changelog — they belong where someone downloading the package will see them, and repeating them per entry is what point 2 just removed). Each release now explains installing over an existing version, that `rpcd` must be restarted because it caches the backend, and that `/etc/config/trafficctl` is preserved as a conffile with the new defaults written aside as `-opkg`.

Since the new section sits after `### Download`, the same trim keeps it out of the changelog automatically.

Verified: YAML parses; the trim tested against the real 1.13.1 body.