### PR TITLE
fix(ci): release notes silently dropped every scoped commit

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -99,7 +99,7 @@ jobs:
             type_regex="$1"
             git log "$RANGE" --reverse --pretty=format:'%H%x09%s%x09%b%x1e' |
               tr -d '\r' |
-              awk -v type_re="^${type_regex}(\\([^)]*\\))?:" \
+              awk -v type_re="^${type_regex}([(][^)]*[)])?:" \
                   -v repo="$REPO" '
                 BEGIN { RS = "\x1e"; FS = "\t" }
                 {


### PR DESCRIPTION
Release bodies have been nearly empty for months — most versions show only the `Full Changelog` link — while **v1.13.0** got a full list. The difference wasn't the releases; it was **who wrote the commits**.

## Root cause
`format_section()` builds its matcher with:
```sh
awk -v type_re="^${type_regex}(\\([^)]*\\))?:"
```
awk processes escape sequences in a `-v` assignment, so `\\(` arrives as `(` and the parentheses become **regex grouping** instead of literal characters. What awk actually receives is:
```
^feat(([^)]*))?:
```
That matches `feat:` but **never** `feat(ui):` — after `feat` the group can only consume non-`)` characters and then requires `:`, so every scoped commit fails to match and is dropped.

Demonstration:
```
$ awk -v type_re="^feat(\\([^)]*\\))?:" 'BEGIN{print type_re}'
^feat(([^)]*))?:
```

v1.13.0 looked healthy only because the contribution it shipped happened to use **unscoped** subjects (`feat: …`), while this repo's own commits are consistently scoped (`feat(ui):`, `fix(wifi):`) — so they all vanished.

## Fix
Use bracket expressions for the literal parens, which escape processing can't mangle:
```
^feat([(][^)]*[)])?:
```

## Verified
Ran the corrected generator over three ranges that previously produced nothing:

| range | now produces |
|---|---|
| `v1.13.0..v1.13.1` | fix: split speed into separate sortable DL and UL columns |
| `v1.10.1..v1.11.0` | feat: support allow-mode (whitelist) ACLs and stop clobbering them |
| `v1.9.0..v1.10.0` | feat: add per-device upload speed column; fix dead live-update selectors |

Both scoped and unscoped subjects match, with the prefix correctly stripped.

Note: this also means the changelog entries the automation writes will be substantive from now on — the empty 1.13.1 entry was a symptom of this same bug.