### PR TITLE
fix(ci): pass the release-notes section regex to awk through the environment

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -115,13 +115,22 @@ jobs:
           # Print one Markdown bullet per commit matching $TYPE_REGEX.
           # Format:  - <subject without prefix> ([short-sha](commit-url))
           #          <up to the first body paragraph, indented> (optional)
+          # The regex reaches awk through the ENVIRONMENT, not -v. awk processes
+          # escape sequences in a -v value, and `\(` is not one it knows, so it
+          # substituted a plain `(` and warned — turning the optional scope group
+          # `(\(...\))?` into a mandatory literal one. Every `fix(scope):` commit
+          # then failed to match while `fixup:`/`fixes:` started matching, so
+          # v1.13.2's notes lost their whole Bug Fixes section. ENVIRON values are
+          # passed through verbatim. (The fault only shows on gawk, which the
+          # GitHub runners use; mawk accepts the -v form, so this cannot be
+          # reproduced on a machine where /usr/bin/awk is mawk or BSD awk.)
           format_section() {
             type_regex="$1"
             git log "$RANGE" --reverse --pretty=format:'%H%x09%s%x09%b%x1e' |
               tr -d '\r' |
-              awk -v type_re="^${type_regex}(\\([^)]*\\))?:" \
-                  -v repo="$REPO" '
-                BEGIN { RS = "\x1e"; FS = "\t" }
+              TYPE_RE="^${type_regex}(\\([^)]*\\))?:" \
+              awk -v repo="$REPO" '
+                BEGIN { RS = "\x1e"; FS = "\t"; type_re = ENVIRON["TYPE_RE"] }
                 {
                   sha=$1; subj=$2; body=$3
                   # Strip whitespace/newlines that creep in between records.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,6 +50,8 @@ jobs:
         run: bash tests/test_regressions.sh
       - name: Release version-bump tests
         run: bash tests/test_release_bump.sh
+      - name: Release notes generator tests
+        run: bash tests/test_changelog_gen.sh
       - name: IPK build test
         run: bash tests/test_build_ipk.sh
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,32 +4,19 @@ All notable changes to luci-app-trafficctl since v1.0.0.
 
 ---
 
-## [1.13.2] - 2026-08-25
+## [Unreleased]
 
-### Other
-- serialise release jobs so they stop racing on git push ([b024f09](https://github.com/YusDyr/luci-app-trafficctl/commit/b024f0966b108b72d850be0dec84bf4154ccb8a5))
-  Merging #40 and #41 four seconds apart started two Auto Release jobs at
-  once. Both computed the same next version and both tried to push main plus
-  the new tag; one won and the other died with "failed to push some refs" —
-  after it had already tagged. The result was a v1.13.1 tag with no GitHub
-  Release and no artifacts behind it.
-- pin the signing action and fix the release state machine ([afbac56](https://github.com/YusDyr/luci-app-trafficctl/commit/afbac56f381b408289ac5b3897c8d767e17dc118))
-  The two release workflows and the compat build all used
-  openwrt/gh-action-sdk@main — a mutable branch in a repository we do not
-  control — and the release paths hand it APK_PRIVATE_KEY and USIGN_PRIVATE_KEY.
-  Anyone able to push there could have added one line to the entrypoint and
-  walked away with the usign key whose public half ships in keys/, then signed
-  packages every existing installation trusts. All three are pinned to the v11
-- anchor the breaking-change footer search to the start of a line ([11edb5f](https://github.com/YusDyr/luci-app-trafficctl/commit/11edb5f59d535cd3dfe279fcbca6adab8052233e))
-  The major-bump condition searched the full commit message for the footer name
-  as free text, unanchored. Conventional Commits defines it as a footer — start
-  of line, followed by ":" or " #" — so any prose that merely named it counted.
+### Bug Fixes
 
-**Full Changelog**: https://github.com/YusDyr/luci-app-trafficctl/compare/v1.13.1...v1.13.2
+- **Release notes silently dropped every scoped commit.** `format_section()` passed its match pattern to awk with `-v`, where awk expands escape sequences in the value: `\(` became a plain `(`, turning the optional scope group into a mandatory literal one. Scoped types like `fix(shaper):` then matched nothing while `fixup:`/`fixes:` matched, so v1.13.2 shipped with no Bug Fixes section at all despite seven `fix(scope):` commits. The pattern now reaches awk through the environment, which is passed through verbatim. Only gawk is affected — the GitHub runners symlink `awk` to it — so the fault is invisible on a machine using mawk or BSD awk.
 
 ---
 
-## [Unreleased]
+## [1.13.2] - 2026-08-25
+
+The release notes published for this version were incomplete: their Bug Fixes,
+Security, Documentation and Tests sections were lost to the generator bug
+recorded under Unreleased above. The full contents of the release follow.
 
 ### Security
 
@@ -61,6 +48,8 @@ All notable changes to luci-app-trafficctl since v1.0.0.
 ### Tests
 
 - Tests that redefined local copies of the functions they claimed to check now exercise the real scripts, and the previously untested rpcd backend, block/unblock, macfilter and metrics CGI are covered. Each bug above has a regression test verified to fail against the old behaviour.
+
+**Full Changelog**: https://github.com/YusDyr/luci-app-trafficctl/compare/v1.13.1...v1.13.2
 
 ---
 

--- a/tests/test_changelog_gen.sh
+++ b/tests/test_changelog_gen.sh
@@ -1,0 +1,221 @@
+#!/bin/bash
+# Tests the release-notes generator in .github/workflows/auto-release.yml.
+#
+# format_section() is EXTRACTED FROM THE WORKFLOW and executed verbatim against
+# a throwaway git repository built here, so the commits it formats are real
+# commits reached through the same `git log` the workflow runs. Keeping a copy
+# of the awk program in this file is what let the scope bug ship: the program
+# was correct as written and only broke in how the regex reached awk.
+#
+# Runs the section under EVERY awk on the box (gawk, mawk, busybox awk, the
+# default /usr/bin/awk). The bug this guards against was invisible on mawk and
+# BSD awk and only appeared on gawk, which is what the GitHub runners use — a
+# single-interpreter test would have reported success.
+
+PASS=0
+FAIL=0
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WF="$REPO_ROOT/.github/workflows/auto-release.yml"
+
+if [ ! -f "$WF" ]; then
+    echo "FAIL: cannot find auto-release.yml at $WF"
+    exit 1
+fi
+
+# The closing brace is matched at the function's own indentation. A looser
+# "first line that is just a brace" would stop inside the awk program, whose
+# blocks close at deeper indents, and silently yield a truncated function.
+FUNC_INDENT=$(sed -n 's/^\( *\)format_section() {.*/\1/p' "$WF" | head -1)
+# `close` is an awk built-in, so the variable cannot be named that.
+FUNC_SRC=$(awk -v endre="^${FUNC_INDENT}}\$" \
+    '/^ *format_section\(\) \{/ { f = 1 }
+     f { print }
+     (f == 1) && ($0 ~ endre) { exit }' "$WF")
+
+if [ -z "$FUNC_SRC" ] ||
+    ! printf '%s\n' "$FUNC_SRC" | grep -q 'git log' ||
+    ! printf '%s\n' "$FUNC_SRC" | grep -qF 'printed >= 6'; then
+    echo "FAIL: could not extract a complete format_section() from $WF."
+    echo "Expected the git log pipeline and the body-line printf. Got:"
+    printf '%s\n' "$FUNC_SRC"
+    exit 1
+fi
+
+# Discover the awk implementations available, so a missing one is reported
+# rather than silently reducing coverage.
+AWKS=""
+for cand in gawk mawk awk; do
+    command -v "$cand" >/dev/null 2>&1 && AWKS="$AWKS $cand"
+done
+if command -v busybox >/dev/null 2>&1 && busybox awk 'BEGIN{}' 2>/dev/null; then
+    AWKS="$AWKS busybox-awk"
+fi
+
+echo "awk implementations under test:$AWKS"
+for a in $AWKS; do
+    case "$a" in
+        busybox-awk) printf '  %-12s %s\n' "busybox" "$(busybox awk --help 2>&1 | head -1)" ;;
+        *) printf '  %-12s %s\n' "$a" "$($a --version 2>&1 | head -1 || $a -W version 2>&1 | head -1)" ;;
+    esac
+done
+if ! printf '%s' "$AWKS" | grep -q gawk; then
+    echo
+    echo "WARNING: gawk is NOT installed here, and gawk is the only awk that"
+    echo "exhibited the escape-sequence bug this file exists to catch. These"
+    echo "results do NOT prove the fix; CI runs on gawk and is authoritative."
+fi
+echo
+
+# ── Build a real repository with the commit shapes that matter ──────────────
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+(
+    cd "$TMP" || exit 1
+    git init -q .
+    git config user.email t@example.com
+    git config user.name Test
+    git config commit.gpgsign false
+    git commit -q --allow-empty -m "chore: baseline"
+    git tag v0.0.1
+
+    git commit -q --allow-empty -m "fix(shaper): allocate classids"
+    git commit -q --allow-empty -m "fix(fw): match comments in full"
+    git commit -q --allow-empty -m "fix: unscoped fix"
+    git commit -q --allow-empty -m "feat(ui): add a graph"
+    git commit -q --allow-empty -m "feat: plain feature"
+    git commit -q --allow-empty -m "perf(metrics): cache the list"
+    git commit -q --allow-empty -m "refactor(fw): split helpers"
+    git commit -q --allow-empty -m "ci: pin the action"
+    git commit -q --allow-empty -m "docs: not released"
+    # Must NOT be picked up as fixes — "fix" is a prefix of both.
+    git commit -q --allow-empty -m "fixup: not a fix commit"
+    git commit -q --allow-empty -m "fixes: also not a fix commit"
+    # The type must be matched at the START of the subject only: a subject that
+    # merely contains "fix:" later on is a different commit, not a bug fix.
+    git commit -q --allow-empty -m "chore: revert the fix: rollback of a thing"
+    # Body handling: lead paragraph is kept, trailers dropped. The trailer sits
+    # directly against the lead paragraph so the trailer rule is what has to
+    # drop it — with a blank line first, the end-of-paragraph rule would stop
+    # output regardless and the trailer rule would never be exercised.
+    git commit -q --allow-empty -m "fix(rpcd): constrain the log path
+
+The path was unvalidated.
+Second line of the lead paragraph.
+Co-Authored-By: Someone <s@example.com>
+Signed-off-by: Someone <s@example.com>
+
+A later paragraph that must not appear."
+) || { echo "FAIL: could not build the fixture repository"; exit 1; }
+
+# Run one section with one awk implementation, from inside the fixture repo.
+run_section() {
+    local impl="$1" type_regex="$2" shim="$TMP/shim"
+    mkdir -p "$shim"
+    case "$impl" in
+        busybox-awk) printf '#!/bin/sh\nexec busybox awk "$@"\n' > "$shim/awk" ;;
+        *) printf '#!/bin/sh\nexec %s "$@"\n' "$(command -v "$impl")" > "$shim/awk" ;;
+    esac
+    chmod +x "$shim/awk"
+    (
+        cd "$TMP" || exit 1
+        PATH="$shim:$PATH"
+        # shellcheck disable=SC2034  # both are read by the eval'd function
+        RANGE="v0.0.1..HEAD"
+        # shellcheck disable=SC2034
+        REPO="owner/repo"
+        eval "$FUNC_SRC"
+        format_section "$type_regex" 2>/dev/null
+    )
+}
+
+assert_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        printf "FAIL: %s\n  expected to find: '%s'\n  in:\n%s\n\n" "$desc" "$needle" "$haystack"
+    fi
+}
+
+assert_not_contains() {
+    local desc="$1" needle="$2" haystack="$3"
+    if printf '%s' "$haystack" | grep -qF -- "$needle"; then
+        FAIL=$((FAIL + 1))
+        printf "FAIL: %s\n  did NOT expect: '%s'\n  in:\n%s\n\n" "$desc" "$needle" "$haystack"
+    else
+        PASS=$((PASS + 1))
+    fi
+}
+
+assert_count() {
+    local desc="$1" expected="$2" haystack="$3" actual
+    actual=$(printf '%s' "$haystack" | grep -c '^- ')
+    if [ "$expected" = "$actual" ]; then
+        PASS=$((PASS + 1))
+    else
+        FAIL=$((FAIL + 1))
+        printf "FAIL: %s\n  expected %s bullets, got %s\n  in:\n%s\n\n" "$desc" "$expected" "$actual" "$haystack"
+    fi
+}
+
+for impl in $AWKS; do
+    echo "── $impl ──"
+
+    FIXES=$(run_section "$impl" "fix")
+
+    # Would have failed before: the scope group became mandatory-literal, so
+    # every scoped fix vanished from the section.
+    assert_contains "$impl: scoped fix(shaper) appears" "allocate classids" "$FIXES"
+    assert_contains "$impl: scoped fix(fw) appears" "match comments in full" "$FIXES"
+    assert_contains "$impl: scoped fix(rpcd) appears" "constrain the log path" "$FIXES"
+    assert_contains "$impl: unscoped fix appears" "unscoped fix" "$FIXES"
+
+    # The scope must be stripped, not left in the bullet text.
+    assert_not_contains "$impl: scope prefix stripped from the bullet" "fix(shaper):" "$FIXES"
+    assert_not_contains "$impl: bare type prefix stripped" "- fix:" "$FIXES"
+
+    # Would have failed before: with `(` literal-and-optional, "fixup:" and
+    # "fixes:" satisfied the pattern and were reported as bug fixes.
+    assert_not_contains "$impl: fixup: is not a fix" "not a fix commit" "$FIXES"
+    assert_not_contains "$impl: fixes: is not a fix" "also not a fix commit" "$FIXES"
+
+    # Other types must not leak into the fix section.
+    assert_not_contains "$impl: feat does not leak into fixes" "add a graph" "$FIXES"
+    assert_not_contains "$impl: docs does not leak into fixes" "not released" "$FIXES"
+    # Would have failed before: an unanchored type match would pull in a chore
+    # whose subject merely contains "fix:" further along.
+    assert_not_contains "$impl: type matched only at subject start" "rollback of a thing" "$FIXES"
+    assert_count "$impl: fix section has exactly 4 bullets" 4 "$FIXES"
+
+    FEATS=$(run_section "$impl" "feat")
+    assert_contains "$impl: scoped feat(ui) appears" "add a graph" "$FEATS"
+    assert_contains "$impl: unscoped feat appears" "plain feature" "$FEATS"
+    assert_count "$impl: feat section has exactly 2 bullets" 2 "$FEATS"
+
+    PERF=$(run_section "$impl" "perf")
+    assert_contains "$impl: scoped perf(metrics) appears" "cache the list" "$PERF"
+    assert_count "$impl: perf section has exactly 1 bullet" 1 "$PERF"
+
+    # The Other section is an alternation, so it exercises the scope group
+    # sitting after a group rather than after a literal type name.
+    OTHER=$(run_section "$impl" "(refactor|ci)")
+    assert_contains "$impl: scoped refactor(fw) appears in Other" "split helpers" "$OTHER"
+    assert_contains "$impl: unscoped ci appears in Other" "pin the action" "$OTHER"
+    assert_count "$impl: other section has exactly 2 bullets" 2 "$OTHER"
+
+    # Body handling.
+    assert_contains "$impl: lead paragraph is included" "The path was unvalidated." "$FIXES"
+    assert_contains "$impl: full lead paragraph is included" "Second line of the lead paragraph." "$FIXES"
+    assert_not_contains "$impl: later paragraphs are dropped" "A later paragraph" "$FIXES"
+    assert_not_contains "$impl: Co-Authored-By trailer dropped" "Co-Authored-By" "$FIXES"
+    assert_not_contains "$impl: Signed-off-by trailer dropped" "Signed-off-by" "$FIXES"
+
+    # Commit links.
+    assert_contains "$impl: bullets link to the commit" "https://github.com/owner/repo/commit/" "$FIXES"
+done
+
+printf "\n%d passed, %d failed\n" "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || exit 1


### PR DESCRIPTION
## Summary

The v1.13.2 release notes have no Bug Fixes section, even though seven `fix(scope):` commits went into that release. The generator's match pattern was mangled on its way into awk, which both hid every scoped commit and let unrelated ones through.

## What went wrong

`format_section()` built its pattern and passed it with `-v`:

```sh
awk -v type_re="^${type_regex}(\\([^)]*\\))?:"
```

awk expands escape sequences in a `-v` value. `\(` is not one it recognises, so it substituted a plain `(` and warned — the [release job log](https://github.com/YusDyr/luci-app-trafficctl/actions/runs/32830101020) carries eight of these, two per `format_section` call:

```
awk: warning: escape sequence `\(' treated as plain `('
awk: warning: escape sequence `\)' treated as plain `)'
```

The optional scope group `(\(...\))?` became a *mandatory literal* one, so the match inverted in both directions:

| Subject | Before | After |
|---|---|---|
| `fix(shaper): allocate classids` | not matched | matched |
| `fix: unscoped` | matched | matched |
| `fixup: not a fix` | **matched** | not matched |
| `fixes: typo` | **matched** | not matched |

So [v1.13.2](https://github.com/YusDyr/luci-app-trafficctl/releases/tag/v1.13.2) published with only an `### Other` section, listing the three unscoped `ci:` subjects that still matched. Had any commit been named `fixup:`, it would have been announced as a bug fix.

The pattern now reaches awk through the environment (`TYPE_RE`), whose values are not escape-processed.

## Why this survived review and CI

**Only gawk is affected.** mawk and BSD awk accept the `-v` form and match correctly. I verified this in an `ubuntu:24.04` container: the base image points `awk` at mawk and the buggy line works, while installing gawk flips `/usr/bin/awk` to it and reproduces both warnings and the failed match. The GitHub runners use gawk, so the fault could only ever appear during a release — never on a developer machine using mawk or BSD awk, and never in a test that ran one interpreter.

The bug predates the release work in #44 (the line dates from `a6963d3`, 30 May); that PR was simply the first release carrying scoped fixes. v1.13.1 had one scoped fix and also has no Bug Fixes section.

## Tests

`tests/test_changelog_gen.sh` extracts `format_section` from the workflow and executes it verbatim against a throwaway git repository, under **every awk on the machine** (gawk, mawk, busybox awk, and whatever `/usr/bin/awk` resolves to). Both properties carry weight:

- A test holding its own copy of the awk program would have passed against the broken workflow — the program text was never wrong, only how the regex reached it.
- A test running one interpreter would have passed under mawk. It also prints a warning when gawk is absent, rather than quietly proving less than it appears to.

Covered: scoped and unscoped subjects for every section, `fixup:`/`fixes:` exclusion, type matched only at subject start, scope prefix stripped from bullet text, per-section bullet counts, lead-paragraph body handling, trailer suppression, and commit links.

## Test plan

- [x] `tests/test_changelog_gen.sh`: **52 assertions, 0 failures** locally (gawk + BSD awk); **78, 0 failures** in an `ubuntu:24.04` container with gawk, mawk and `awk`→gawk
- [x] Six mutations fail the test, including reverting to the `-v` form (22 of 52 assertions fail; 33 of 78 in the container). Verified the same mutation passes 48/48 against an earlier draft of the test that only lifted the regexes — which is why it executes the function instead
- [x] Diagnosis confirmed against the real runner log, not just reasoned about: 8 escape warnings, and the emitted body contains `### Other` with no `### Bug Fixes`
- [x] Ran the fixed generator over `v1.13.2..HEAD`: this branch's own `fix(ci):` commit now lands in Bug Fixes with its prefix stripped — under the old code it would have vanished
- [x] `shellcheck -x -e SC1091 -S warning` clean across all 53 scripts; both workflow files parse as YAML
- [x] Simulated the workflow's CHANGELOG insertion against the restructured file: the next release's entry lands above `[Unreleased]` without swallowing it

## Also in this PR

`CHANGELOG.md` had the same truncated notes for 1.13.2, because the workflow writes the generated body into the file. Restored from the `[Unreleased]` section that described that release, with a line recording that the published notes were incomplete.

## Not addressed

The workflow inserts each new entry above `[Unreleased]` rather than consuming it, so a hand-maintained `[Unreleased]` section persists after the release that shipped it and has to be cleared by hand. That is pre-existing behaviour and out of scope here.
