### PR TITLE
fix(ci): stop release notes hanging on a commit that cites an issue

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -141,10 +141,19 @@ jobs:
                   # Strip "type(scope): " prefix.
                   sub(type_re " *", "", subj)
                   # Auto-link bare "#NN" refs to PR/issue.
-                  while (match(subj, /#[0-9]+/)) {
-                    n = substr(subj, RSTART+1, RLENGTH-1)
-                    subj = substr(subj,1,RSTART-1) "[#" n "](https://github.com/" repo "/issues/" n ")" substr(subj, RSTART+RLENGTH)
+                  # Consume the subject left to right, appending to `out`, so a
+                  # replacement is never rescanned. Rewriting `subj` in place and
+                  # re-matching from the start loops forever: the substitution
+                  # itself contains "#NN" (inside "[#NN](...)"), so match() keeps
+                  # finding it and the string grows without bound. Any commit
+                  # subject carrying an issue ref would hang the release job.
+                  out = ""; rest = subj
+                  while (match(rest, /#[0-9]+/)) {
+                    n = substr(rest, RSTART+1, RLENGTH-1)
+                    out = out substr(rest,1,RSTART-1) "[#" n "](https://github.com/" repo "/issues/" n ")"
+                    rest = substr(rest, RSTART+RLENGTH)
                   }
+                  subj = out rest
                   printf "- %s ([%s](https://github.com/%s/commit/%s))\n", subj, short, repo, sha
 
                   # Emit body lines, stopping at first blank line (lead


### PR DESCRIPTION
Found while backfilling old release bodies. Latent, but it would take the release job down completely.

## The bug
The auto-linking loop rewrites `subj` in place and re-matches from the start:

```awk
while (match(subj, /#[0-9]+/)) {
  n = substr(subj, RSTART+1, RLENGTH-1)
  subj = substr(subj,1,RSTART-1) "[#" n "](.../issues/" n ")" substr(subj, RSTART+RLENGTH)
}
```

The replacement it inserts **still contains `#NN`** — inside `[#NN](...)` — so `match()` finds the same reference again next pass, wraps it again, and the string grows without bound. **The loop never exits.**

Reproduced with `fix: handle #42 correctly`:
```
fix: handle [[[[[#42](https://github.com/.../issues/42)](https://github.com/.../issues/42)]...
```
…and it keeps growing.

## Why it hasn't bitten yet
No commit subject carrying a conventional prefix has contained an issue reference — those refs normally live in the commit *body*, which this code doesn't scan. The first `fix: … #42 …` **subject** would hang *Tag, release & build* until the 6-hour job timeout: minutes burned, nothing published, and a half-made release (the tag is pushed earlier in the job).

## Fix
Consume the subject left to right into an accumulator, so a replacement is never rescanned.

## Verified
Extracted the patched awk block **from this file** and ran it — not a reimplementation:

| input | output |
|---|---|
| `handle #42 correctly` | `handle [#42](…/issues/42) correctly` |
| `close #7 and #13` | both linked |
| `no refs here` | unchanged |

All terminate.

---

Context: the sibling bug (scoped commits like `feat(ui):` being dropped) was already fixed in main via `ENVIRON`, so I closed #43. I also backfilled the `What's Changed` sections of v1.8.0, v1.9.0, v1.10.0, v1.10.1, v1.11.0, v1.12.0, v1.12.1 and v1.13.1, preserving each Download/Upgrading section.