### PR TITLE
docs: fix apk download filename and document uninstalling

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -141,10 +141,19 @@ jobs:
                   # Strip "type(scope): " prefix.
                   sub(type_re " *", "", subj)
                   # Auto-link bare "#NN" refs to PR/issue.
-                  while (match(subj, /#[0-9]+/)) {
-                    n = substr(subj, RSTART+1, RLENGTH-1)
-                    subj = substr(subj,1,RSTART-1) "[#" n "](https://github.com/" repo "/issues/" n ")" substr(subj, RSTART+RLENGTH)
+                  # Consume the subject left to right, appending to `out`, so a
+                  # replacement is never rescanned. Rewriting `subj` in place and
+                  # re-matching from the start loops forever: the substitution
+                  # itself contains "#NN" (inside "[#NN](...)"), so match() keeps
+                  # finding it and the string grows without bound. Any commit
+                  # subject carrying an issue ref would hang the release job.
+                  out = ""; rest = subj
+                  while (match(rest, /#[0-9]+/)) {
+                    n = substr(rest, RSTART+1, RLENGTH-1)
+                    out = out substr(rest,1,RSTART-1) "[#" n "](https://github.com/" repo "/issues/" n ")"
+                    rest = substr(rest, RSTART+RLENGTH)
                   }
+                  subj = out rest
                   printf "- %s ([%s](https://github.com/%s/commit/%s))\n", subj, short, repo, sha
 
                   # Emit body lines, stopping at first blank line (lead

--- a/README.md
+++ b/README.md
@@ -259,14 +259,14 @@ The "stable URL" links below always download from the latest release — the fil
 # Add the signing key (one-time):
 wget -O /etc/apk/keys/luci-app-trafficctl.pub https://raw.githubusercontent.com/YusDyr/luci-app-trafficctl/main/keys/apk-signing.pub
 # Install:
-cd /tmp && wget https://github.com/YusDyr/luci-app-trafficctl/releases/latest/download/luci-app-trafficctl.apk && apk add luci-app-trafficctl.apk
+cd /tmp && wget -O luci-app-trafficctl.apk https://github.com/YusDyr/luci-app-trafficctl/releases/latest/download/luci-app-trafficctl.apk && apk add luci-app-trafficctl.apk
 # If you get "modified conffile" on upgrade, add `--force-maintainer` to override
 ```
 
 **Option C — SSH (without key, quick install):**
 
 ```sh
-cd /tmp && wget https://github.com/YusDyr/luci-app-trafficctl/releases/latest/download/luci-app-trafficctl.apk && apk add --allow-untrusted luci-app-trafficctl.apk
+cd /tmp && wget -O luci-app-trafficctl.apk https://github.com/YusDyr/luci-app-trafficctl/releases/latest/download/luci-app-trafficctl.apk && apk add --allow-untrusted luci-app-trafficctl.apk
 ```
 
 ### OpenWrt 21.02 — 24.10 (.ipk)
@@ -286,6 +286,39 @@ opkg install https://github.com/YusDyr/luci-app-trafficctl/releases/latest/downl
 
 ```sh
 ssh root@router 'opkg install https://github.com/YusDyr/luci-app-trafficctl/releases/latest/download/luci-app-trafficctl.ipk'
+```
+
+### Uninstalling
+
+```sh
+# OpenWrt 25.12+ (apk)
+apk del luci-app-trafficctl
+
+# OpenWrt 21.02 - 24.10 (opkg)
+opkg remove luci-app-trafficctl
+
+# either way, reload the LuCI backend afterwards
+/etc/init.d/rpcd restart
+```
+
+Removing the package deletes its scripts and the LuCI page but leaves
+`/etc/config/trafficctl` in place, so your settings survive a reinstall. Delete
+it yourself if you want a clean slate:
+
+```sh
+rm -f /etc/config/trafficctl
+```
+
+Any blocks, rate limits or shapers that were active are **not** persistent
+firewall/tc state — they disappear on the next reboot. To clear them
+immediately before removing the package, unblock/unlimit the affected devices
+from the dashboard first, or reboot the router after uninstalling.
+
+If you also enabled the Telegram bot, stop it before removing:
+
+```sh
+/etc/init.d/trafficctl-telegram stop
+/etc/init.d/trafficctl-telegram disable
 ```
 
 ### From source (OpenWrt build system)


### PR DESCRIPTION
Two user-reported documentation gaps.

**1. The apk install command saves the file under the wrong name** — reported by @LeonWilzer in #47.

GitHub redirects a release download to a blob URL carrying query parameters, so `wget <url>` writes a file literally named `3345afb4-7fa5-44e7-a0ad-35075ac0f86d?sp=r`, and the `apk add luci-app-trafficctl.apk` that follows can't find it. Added `-O luci-app-trafficctl.apk` to both apk commands, exactly as they suggested. The opkg instructions hand the URL straight to opkg, so they were never affected.

**2. There were no uninstall instructions** — asked by @topsbr on the OpenWrt forum ("How do I remove this, in case I want to?").

Adds an *Uninstalling* section covering `apk del` / `opkg remove`, the `rpcd` restart afterwards, the fact that `/etc/config/trafficctl` is deliberately kept so settings survive a reinstall (with the command to remove it), that active blocks/limits are runtime-only state rather than persistent config, and stopping the Telegram bot first if it was enabled.

---

**Not** included: the `UNTRUSTED signature` half of #47. So far I've confirmed the signed-build step succeeds in the release job and `keys/apk-signing.pub` is a P-256 EC key (the type apk-tools v3 wants), so the package does get signed — the failure is more likely in how the key is matched at install time. I've asked the reporter for the diagnostics that would pin it down rather than guess.