### PR TITLE
docs: drop the signature-verified apk install, it cannot work

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,21 +253,22 @@ The "stable URL" links below always download from the latest release — the fil
 2. In LuCI: **System → Software → Upload Package...**
 3. Select the downloaded file and click **OK**
 
-**Option B — SSH (with signature verification):**
-
-```sh
-# Add the signing key (one-time):
-wget -O /etc/apk/keys/luci-app-trafficctl.pub https://raw.githubusercontent.com/YusDyr/luci-app-trafficctl/main/keys/apk-signing.pub
-# Install:
-cd /tmp && wget -O luci-app-trafficctl.apk https://github.com/YusDyr/luci-app-trafficctl/releases/latest/download/luci-app-trafficctl.apk && apk add luci-app-trafficctl.apk
-# If you get "modified conffile" on upgrade, add `--force-maintainer` to override
-```
-
-**Option C — SSH (without key, quick install):**
+**Option B — SSH (recommended):**
 
 ```sh
 cd /tmp && wget -O luci-app-trafficctl.apk https://github.com/YusDyr/luci-app-trafficctl/releases/latest/download/luci-app-trafficctl.apk && apk add --allow-untrusted luci-app-trafficctl.apk
+# If you get "modified conffile" on upgrade, add `--force-maintainer` to override
 ```
+
+> **Why `--allow-untrusted`?** OpenWrt does not sign individual `.apk` files —
+> package signatures apply to a repository *index*, not to a standalone file
+> downloaded from a GitHub release. Upstream removed per-package apk signing
+> outright in October 2025. `--allow-untrusted` is therefore the normal way to
+> install a single package file, not a security workaround being suggested
+> lightly. If you want to pin what you install, download the version-stamped
+> asset (`luci-app-trafficctl_X.Y.Z-r1_noarch.apk`) rather than the floating
+> `latest` URL, so the file cannot change under you between download and
+> install.
 
 ### OpenWrt 21.02 — 24.10 (.ipk)
 


### PR DESCRIPTION
Closes the second half of #47. @LeonWilzer followed the documented signature-verified install for 25.12+ and got `UNTRUSTED signature`. The instructions were wrong, not their setup.

## The package isn't signed at all

I first assumed it *was* signed, because the release job's "Build .apk (via OpenWrt SDK, signed)" step succeeds — but that only means the build didn't fail, not that a signature block was produced. Tracing it through OpenWrt's build system:

- `openwrt/gh-action-sdk` turns our secrets into **`CONFIG_SIGNED_PACKAGES`**.
- Signing an individual `.apk` in `include/package-pack.mk` is gated on **`CONFIG_SIGN_EACH_PACKAGE`** — a different symbol the action never sets. Prebuilt SDK tarballs come from OpenWrt's buildbot and ship `CONFIG_BUILDBOT=y`, under which that symbol defaults **off**.
- Upstream then removed per-package apk signing outright — *"package: do not sign individual APK packages"* (Oct 2025) — clarifying that `SIGNED_PACKAGES` governs the repository **index**, not standalone files.

So Option B could never have worked, on any release.

## Why nothing caught it
Every install test runs `apk add --allow-untrusted`. The signed path had **zero** coverage, so a documented flow that cannot succeed shipped unnoticed.

## This change
- Replaces the key-installation option with the one that works.
- Explains *why* `--allow-untrusted` is correct for a standalone file, so it doesn't read as a careless shrug at security.
- Suggests the version-stamped asset for pinning.
- Deliberately does **not** suggest comparing a checksum — I checked, and releases don't publish any. (Adding checksums to the release body would be a reasonable follow-up.)

Real verification would mean publishing a signed apk *repository index* that users add to `/etc/apk/repositories` — worthwhile, but a separate piece of work.

Note: `keys/apk-signing.pub` is now unreferenced by the docs. I've left the file in place rather than delete it in a docs PR, in case the repo-index route is taken later.