### PR TITLE
ci: tell "snapshot feeds are down" apart from "our package is broken"

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -115,12 +115,30 @@ jobs:
           else
             PKG="/dist/luci-app-trafficctl_0.0.0-test-1_all.ipk"
           fi
+          set +e
           docker run --rm \
             --entrypoint /bin/sh \
             -v "$PWD/dist:/dist" \
             -v "$PWD/tests:/tests" \
             "$IMAGE" \
             /tests/test_install.sh "$PKG"
+          rc=$?
+          set -e
+          # 78 means the image's package feeds were unreachable, so the test
+          # could not resolve dependencies and never got to judge our package.
+          # Tolerated ONLY for the rolling snapshot target, whose feeds are
+          # rebuilt continuously and are legitimately unavailable at times.
+          # A pinned release with dead feeds is itself worth a red build, and
+          # any other failure stays red everywhere.
+          if [ "$rc" = "78" ]; then
+            if [ "${{ matrix.version }}" = "snapshot" ]; then
+              echo "::warning::snapshot feeds unavailable — package not verified on snapshot this run"
+              exit 0
+            fi
+            echo "::error::package feeds unavailable for ${{ matrix.version }} (pinned release — not tolerated)"
+            exit 1
+          fi
+          exit $rc
 
   # ──────────────────────────────────────────────────────────────────────────
   # Feed install — reproduce the user-facing `./scripts/feeds update` workflow

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -50,6 +50,17 @@ case "$PKG" in
     *.apk)
         echo "Installing APK package..."
         if command -v apk >/dev/null 2>&1; then
+            # Installing a local .apk still resolves its dependencies from the
+            # distribution feeds, so unreachable feeds make this test impossible
+            # to run — a different thing from the package being broken. Probe
+            # first and report that distinctly (78), so the caller can tell
+            # "upstream is down" from "our package failed to install".
+            if ! apk update >/tmp/apk-update.out 2>&1; then
+                echo "::warning::package feeds are unreachable in this image:"
+                tail -5 /tmp/apk-update.out
+                echo "SKIP: cannot resolve dependencies, upstream feeds unavailable"
+                exit 78
+            fi
             # Tolerate post-install hook failures from OTHER packages (e.g.,
             # upstream rpcd-mod-luci / rpcd-mod-ucode post-install scripts in
             # the snapshot rootfs occasionally exit non-zero). What matters is


### PR DESCRIPTION
`snapshot / x86-64` has failed on **every** open PR for two days, blocking #48, #49 and #50 — none of which could plausibly affect it (two changed only `README.md`, one only an awk expression inside a workflow).

## What's actually happening
Inside the snapshot container:
```
ERROR: wget: exited with error 8
ERROR: unable to select packages:
ERROR: apk add failed and luci-app-trafficctl is not installed.
```
OpenWrt's rolling snapshot feeds aren't serving. Evidence it's external:
- the same job passed on main on 2026-09-04
- the container tag resolves fine (ghcr returns HTTP 200 for `x86-64-snapshot`)
- reruns a full day apart fail identically
- it fails on every open PR regardless of content

Installing a local `.apk` still resolves its **dependencies** from the feeds, so unreachable feeds make the test impossible to run — a different outcome from *our package failing to install*, yet both produced the same red X.

## The change
- `test_install.sh` probes the feeds with `apk update` before installing, and exits **78** if they're unreachable, printing why.
- `compat.yml` treats 78 as a skip **only** for the rolling `snapshot` target, with a `::warning::` so the run still records that the package went unverified there.

## Why it's this narrow
The obvious fix — `continue-on-error` on the job — is the wrong one. That's precisely the pattern that previously let feed-install regressions ship green, and it was removed for that reason. So instead:

| situation | result |
|---|---|
| feeds down, `snapshot` | skip + warning |
| feeds down, pinned release (23.05.6 / 24.10.6 / 25.12.4) | **red** — that would be its own story |
| package fails to install, any version | **red** |
| anything else | unchanged |

Verified the decision matrix and that `test_install.sh` still passes `dash -n` and `shellcheck -S warning`. The ipk path is untouched (the probe lives in the apk branch).
