### PR TITLE
fix: nft byte counters reported download and upload swapped

### DIFF
--- a/luci-app-trafficctl/root/usr/local/bin/trafficctl-bytes-nft.sh
+++ b/luci-app-trafficctl/root/usr/local/bin/trafficctl-bytes-nft.sh
@@ -8,8 +8,24 @@
 
 command -v nft >/dev/null 2>&1 || { echo '[]'; exit 0; }
 
-# Create table/maps/chain/rules if not already present (idempotent)
-if ! nft list chain inet trafficctl_mon mon_forward 2>/dev/null | grep -q "saddr"; then
+# Create table/maps/chain/rules if not already present (idempotent).
+#
+# The gate matches the CURRENT rule orientation, not merely "some rule exists".
+# Until 1.13.x the maps were keyed the other way round (bytes_in by saddr), so
+# a router upgrading from that version already has the chain: a looser check
+# would leave the old, inverted rules in place forever and the fix would only
+# ever reach fresh installs.
+#
+# Direction convention, matching trafficctl-bytes.sh and docs/API.md:
+#   bytes_in  = traffic toward the device  (download) -> keyed by ip daddr
+#   bytes_out = traffic from the device    (upload)   -> keyed by ip saddr
+if ! nft list chain inet trafficctl_mon mon_forward 2>/dev/null | grep -q "bytes_in.*daddr"; then
+    # Drop the old table wholesale rather than appending to it — leaving the
+    # previous pair of rules in place would double-count every packet. This
+    # resets the counters once, on upgrade; they are only used for speed
+    # deltas, so a single discarded sample is the whole cost.
+    nft delete table inet trafficctl_mon 2>/dev/null
+
     nft add table inet trafficctl_mon 2>/dev/null
     nft add map inet trafficctl_mon bytes_in \
         '{ type ipv4_addr : counter; flags dynamic; }' 2>/dev/null
@@ -18,9 +34,9 @@ if ! nft list chain inet trafficctl_mon mon_forward 2>/dev/null | grep -q "saddr
     nft add chain inet trafficctl_mon mon_forward \
         '{ type filter hook forward priority -200; policy accept; }' 2>/dev/null
     nft add rule inet trafficctl_mon mon_forward \
-        'update @bytes_in { ip saddr counter }' 2>/dev/null
+        'update @bytes_in { ip daddr counter }' 2>/dev/null
     nft add rule inet trafficctl_mon mon_forward \
-        'update @bytes_out { ip daddr counter }' 2>/dev/null
+        'update @bytes_out { ip saddr counter }' 2>/dev/null
 fi
 
 # Dynamic counter maps are unsupported on some kernels ("Not supported").

--- a/tests/test_bytes_nft.sh
+++ b/tests/test_bytes_nft.sh
@@ -152,6 +152,94 @@ OUT=$(run_bytes_nft)
 assert_eq "output starts with ["  "[" "$(echo "$OUT" | cut -c1)"
 assert_eq "output ends with ]"    "]" "$(echo "$OUT" | rev | cut -c1)"
 
+# ── rule orientation: which map each direction is keyed by ──────────────────
+#
+# The maps used to be keyed the wrong way round: bytes_in by `ip saddr`, which
+# is traffic the device SENT, i.e. its upload — while trafficctl-bytes.sh (the
+# conntrack backend this script substitutes for), docs/API.md and the DL/UL
+# columns in status.js all define bytes_in as download. The same RPC call
+# returned DL and UL swapped depending on the router's offload mode.
+#
+# These tests pin the orientation at the point where the rules are created,
+# not where the output is parsed, so a future swap in the awk cannot make them
+# pass while the counters are wrong.
+
+NFT_LOG="$TMPDIR/nft.log"
+CHAIN_FILE="$TMPDIR/chain.txt"
+
+cat > "$MOCKBIN/nft" <<MOCK
+#!/bin/sh
+echo "\$*" >> "$NFT_LOG"
+case "\$*" in
+    "list tables") echo "table inet fw4" ;;
+    "list chain inet trafficctl_mon mon_forward") cat "$CHAIN_FILE" 2>/dev/null ;;
+    "list map inet trafficctl_mon bytes_in") cat "$BYTES_IN_FILE" 2>/dev/null ;;
+    "list map inet trafficctl_mon bytes_out") cat "$BYTES_OUT_FILE" 2>/dev/null ;;
+    *) exit 0 ;;
+esac
+exit 0
+MOCK
+chmod +x "$MOCKBIN/nft"
+
+cat > "$BYTES_IN_FILE" <<'EOF'
+elements = { 192.168.0.100 : counter packets 584 bytes 892341 }
+EOF
+cat > "$BYTES_OUT_FILE" <<'EOF'
+elements = { 192.168.0.100 : counter packets 312 bytes 45678 }
+EOF
+
+# fresh install — no chain yet
+: > "$CHAIN_FILE"
+: > "$NFT_LOG"
+run_bytes_nft >/dev/null
+
+assert_eq "fresh: bytes_in is keyed by daddr (download)" "1" \
+    "$(grep -c 'add rule inet trafficctl_mon mon_forward update @bytes_in { ip daddr counter }' "$NFT_LOG")"
+assert_eq "fresh: bytes_out is keyed by saddr (upload)" "1" \
+    "$(grep -c 'add rule inet trafficctl_mon mon_forward update @bytes_out { ip saddr counter }' "$NFT_LOG")"
+assert_eq "fresh: no inverted bytes_in rule" "0" \
+    "$(grep -c '@bytes_in { ip saddr counter }' "$NFT_LOG")"
+
+# upgrade from a router that already carries the old, inverted rules.
+# The creation gate must NOT accept them: a looser check ("does any rule
+# mention saddr?") matches the broken chain too, so the corrected rules would
+# only ever reach fresh installs.
+cat > "$CHAIN_FILE" <<'EOF'
+table inet trafficctl_mon {
+	chain mon_forward {
+		type filter hook forward priority -200; policy accept;
+		update @bytes_in { ip saddr counter }
+		update @bytes_out { ip daddr counter }
+	}
+}
+EOF
+: > "$NFT_LOG"
+run_bytes_nft >/dev/null
+
+assert_eq "upgrade: stale table is dropped" "1" \
+    "$(grep -c '^delete table inet trafficctl_mon$' "$NFT_LOG")"
+assert_eq "upgrade: corrected bytes_in rule is installed" "1" \
+    "$(grep -c 'update @bytes_in { ip daddr counter }' "$NFT_LOG")"
+
+# already correct — must be a no-op, or every poll would delete and rebuild
+# the table and the counters would never accumulate.
+cat > "$CHAIN_FILE" <<'EOF'
+table inet trafficctl_mon {
+	chain mon_forward {
+		type filter hook forward priority -200; policy accept;
+		update @bytes_in { ip daddr counter }
+		update @bytes_out { ip saddr counter }
+	}
+}
+EOF
+: > "$NFT_LOG"
+run_bytes_nft >/dev/null
+
+assert_eq "correct chain: table is not dropped" "0" \
+    "$(grep -c '^delete table' "$NFT_LOG")"
+assert_eq "correct chain: no rules re-added" "0" \
+    "$(grep -c '^add rule' "$NFT_LOG")"
+
 # ── unsupported dynamic counter maps: falls back to conntrack script ────────
 # When `nft list map ... bytes_in` fails (kernel lacks dynamic counter maps),
 # the script must re-exec trafficctl-bytes.sh instead of returning [] forever.


### PR DESCRIPTION
Found while surveying the byte-counting path for the cumulative-counters work in #26.

## The bug

`trafficctl-bytes-nft.sh` created its maps like this:

```
update @bytes_in  { ip saddr counter }
update @bytes_out { ip daddr counter }
```

In the forward hook, a packet whose **source** is a LAN device is that device's **upload**. So `bytes_in` accumulated upload and `bytes_out` accumulated download — the opposite of what every consumer expects:

| consumer | definition |
|---|---|
| `trafficctl-bytes.sh` (conntrack backend) | `in_total += bytes_reply` → `bytes_in` is download |
| `docs/API.md` | "`bytes_in` — Total bytes received (download = conntrack reply direction)" |
| `status.js` | `bytes_in` → **DL Speed**, `bytes_out` → **UL Speed** |
| `trafficctl-metrics.sh` | `bytes_in` → `direction="rx"` |

Because `trafficctl-bytes.sh` execs the nft script as its own fallback, **the same RPC method returned DL and UL swapped depending on router configuration** — not a naming nit, a wrong answer.

## Who was affected

The conntrack path is kept for offload modes `none` and `*-counter`; anything else hands off to the nft script. So the swap showed up on routers running **flow offload with a flowtable that lacks the counter flag**, and whose kernel supports dynamic counter maps (without them the script bounces back to conntrack). fw4 sets the counter flag by default on 22.03+, which is why this survived unnoticed — and why it would have looked like a mystery to the one user who hit it.

Both the LuCI columns and the Prometheus `rx`/`tx` series were affected.

## The upgrade trap, fixed in the same change

The creation gate was:

```sh
if ! nft list chain inet trafficctl_mon mon_forward | grep -q "saddr"; then
```

The old inverted chain *also* mentions `saddr`. On any router that already had the table, that check would keep passing and the corrected rules would never be installed — the fix would silently reach fresh installs only. The gate now matches the current orientation and rebuilds the table when it finds the old one.

That resets those counters once, on upgrade. They only feed speed deltas, so the cost is a single discarded sample.

## Tests

Pinned at **rule creation**, not at output parsing — `tests/test_bytes_nft.sh` already asserted that map content reaches the same-named field, which stays true under an inverted rule set. The new assertions cover orientation on fresh install, the upgrade rebuild, and that a correct chain is left alone (otherwise every poll would rebuild the table and the counters would never accumulate).

Verified they fail **5/5 against the pre-fix script** and pass after. ShellCheck and the dash/bashism suite are clean.
